### PR TITLE
Add support for eventstream, REST layer, fix cordapp and readme update

### DIFF
--- a/README
+++ b/README
@@ -1,1 +1,0 @@
-## Blockchain connector for corda (WIP)

--- a/README.md
+++ b/README.md
@@ -1,0 +1,249 @@
+# Blockchain connector for corda
+- FireFly Cordapp
+- Connector springboot application
+  - Exposes REST endpoint to interact with firefly cordapp
+  - Exposes REST endpoints to manage eventstreams and subscriptions
+  - Exposes Websocket endpoint to consume events from corda ledger 
+## PRE-REQS
+- JDK 11 (such as from [https://adoptopenjdk.net/](https://gradle.org/install/))
+- gradle ([https://gradle.org/install/](https://gradle.org/install/))
+
+## BUILD
+```
+./gradlew build
+```
+
+The outputs are in these folders:
+
+- Cordapp jars
+  - `cordapp/firefly-contracts/build/libs/firefly-contracts.jar`
+  - `cordapp/firefly-flows/build/libs/firefly-flows.jar`
+- Connector springboot application
+  - `connector/build/libs/connector.jar`
+  
+## Running locally
+
+### Prerequisites
+
+- Install above cordapps on corda nodes in your corda network
+
+### Running connector locally
+
+- Run following command to run the connector springboot application
+
+```
+./gradlew bootRun --args='--rpc.host=<rpc host for corda node> --rpc.username=test --rpc.password=client123!'
+```
+
+- Open `http://localhost:8080/swagger-ui/index.html` to view rest endpoints available.
+- Create an eventstream using `POST /eventstream`, example request body
+
+```
+{
+  "data": {
+    "name": "eventstream-0",
+    "batchSize": 10,
+    "batchTimeoutMS": 5000,
+    "blockedRetryDelaySec": 20,
+    "errorHandling": "BLOCK",
+    "websocket": {
+      "topic": "eventstream-0-topic"
+    }
+  }
+}
+```
+
+- Note the eventstream id from the response
+
+```
+{
+  "statusCode": 200,
+  "status": true,
+  "message": "SUCCESS",
+  "data": {
+    "id": "es-622a2ff8-b688-46b2-874b-de7c5cd4e8dc",
+    "name": "eventstream-0",
+    "batchSize": 10,
+    "batchTimeoutMs": 5000,
+    "batchRetryDelaySec": 20,
+    "errorHandling": "BLOCK",
+    "websocketTopic": "eventstream-0-topic",
+    "suspended": false,
+    "created": "2021-06-24T19:49:53.775Z",
+    "updated": null
+  }
+}
+```
+
+- Create an subscription using `POST /subscriptions`, example request body using id of eventstream created in previous step
+
+```
+{
+  "data": {
+    "fromTime": "2021-06-24T19:54:17.776Z",
+    "stream": "es-622a2ff8-b688-46b2-874b-de7c5cd4e8dc",
+    "filter": {
+      "stateType": "io.kaleido.firefly.cordapp.states.BroadcastBatch",
+      "stateStatus": "UNCONSUMED",
+      "relevancyStatus": "RELEVANT"
+    },
+    "name": "subscription-0"
+  }
+}
+```
+
+- response 
+
+```
+{
+  "statusCode": 200,
+  "status": true,
+  "message": "SUCCESS",
+  "data": {
+    "id": "sb-6dd6e475-b2ed-4109-9831-b259e9b08ef2",
+    "name": "subscription-0",
+    "stream": {
+      "id": "es-622a2ff8-b688-46b2-874b-de7c5cd4e8dc",
+      "name": "eventstream-0",
+      "batchSize": 10,
+      "batchTimeoutMs": 5000,
+      "batchRetryDelaySec": 20,
+      "errorHandling": "BLOCK",
+      "websocketTopic": "eventstream-0-topic",
+      "suspended": false,
+      "created": "2021-06-24T19:49:53.775Z",
+      "updated": null
+    },
+    "stateType": "io.kaleido.firefly.cordapp.states.BroadcastBatch",
+    "stateStatus": "UNCONSUMED",
+    "relevancyStatus": "RELEVANT",
+    "fromTime": "2021-06-24T19:54:17.776Z",
+    "lastCheckpoint": null,
+    "created": "2021-06-24T19:56:15.845Z",
+    "updated": null
+  }
+}
+```
+
+- setup websocket client to listen to corda events, you can use following node sample
+
+```
+const WebSocket = require('ws')
+const ws = new WebSocket(`ws://localhost:8080/ws`);
+let lastAck = null;
+let heartBeatTimeout = setTimeout(() => {
+  console.error('Event stream ping timeout');
+  ws.terminate();
+}, 10000);
+const heartBeat = () => {
+  ws.ping();
+  clearTimeout(heartBeatTimeout);
+  heartBeatTimeout = setTimeout(() => {
+    console.error('Event stream ping timeout');
+    ws.terminate();
+  }, 2000);
+}
+
+ws.on('open', () => {
+  ws.send(JSON.stringify({
+    type: 'listen',
+    topic: 'eventstream-0-topic'
+  }));
+  heartBeat();
+}).on('close', () => {
+  console.error(`Event stream websocket disconnected`);
+}).on('message', async (message) => {
+  const data = JSON.parse(message);
+  for(var i=0; i<data.length; i++) { 
+    console.log(JSON.stringify(data[i]));
+  }
+  ws.send(JSON.stringify({
+    type: 'ack',
+    topic: 'eventstream-0-topic'
+  }));
+}).on('pong', () => {
+  heartBeat();
+}).on('error', err => {
+  console.error(`Event stream websocket error. ${err}`);
+});
+```
+
+- send a firefly transaction using `POST /broadcastBatch`, request body
+
+```
+{
+  "data": {
+    "batchId": "batch-id-0",
+    "payloadRef": "some-payload-ref-0",
+    "observers": [
+      "CN=Node of u0xrgv6atc for u0fifdgpl8, O=Kaleido, L=Raleigh, C=US"
+    ],
+    "groupId": "3fa85f64-5717-4562-b3fc-2c963f66afa6"
+  }
+}
+```
+
+- you would receive transaction hash as response 
+```
+{
+  "statusCode": 200,
+  "status": true,
+  "message": "SUCCESS",
+  "data": "891F8893DB10130413C4D504F42395C9D8C788684074C325DCE115E8DBF915CE"
+}
+```
+
+- On websocket client you would receive the event message from corda
+
+```
+{
+    "data":
+    {
+        "data":
+            {
+                "@class":"io.kaleido.firefly.cordapp.states.BroadcastBatch",
+                "author":"CN=Node of u0jh5fc7yc for u0fifdgpl8, O=Kaleido, L=Raleigh, C=US",
+                "batchId":"batch-id-0",
+                "payloadRef":"some-payload-ref-0",
+                "participants":["CN=Node of u0xrgv6atc for u0fifdgpl8, O=Kaleido, L=Raleigh, C=US","CN=Node of u0jh5fc7yc for u0fifdgpl8, O=Kaleido, L=Raleigh, C=US"]
+            },
+            "contract":"io.kaleido.firefly.cordapp.contracts.FireflyContract",
+            "notary":"CN=Node of u0congcs2l for u0fifdgpl8, O=Kaleido, L=Raleigh, C=US",
+            "encumbrance":null,
+            "constraint":
+            {
+                "@class":"net.corda.core.contracts.SignatureAttachmentConstraint",
+                "key":"3mviYCPz42wQCX8yUe3fdhFKHg7ZDA1dthqUQF946tgfUC43hosoa8Ef98JXufsSVMW8C6L3UEHhh4kdKr1xashDNWuacM5F43dL9Btzs534H2iEksEDX3aWWAMgXBMj88jiEmQi7orS2VSrpB29QNGYTKWZrcKrK4oJm3bYNKiv4Smrkd5zWoZQ8Tzz2HKamvSXqQ2s3MxTYXZrJ6zTz2rEMjXBF3s1d8tPqV3LBhvpDwG4MaVhg3UREzKkZGe58T8x1QJ4GEu6TGU43T3VJ295dyZSEguXj6v1g6HVqTPE8CnLvszy31E3xSBGU2sQFNeC"
+            }
+        },
+        "subId":"sb-6dd6e475-b2ed-4109-9831-b259e9b08ef2",
+        "signature":"io.kaleido.firefly.cordapp.states.BroadcastBatch",
+        "stateRef":
+        {
+            "txhash":"891F8893DB10130413C4D504F42395C9D8C788684074C325DCE115E8DBF915CE",
+            "index":0
+        },
+        "recordedTime":"2021-06-24T20:04:30.361398Z",
+        "consumedTime":null
+}
+```
+
+## TODOS
+- Solve broadcast problem for corda
+    - All communication is corda is point to point, and there is no concept of global blockchain state in corda.
+    - We currently solve it by passing a list of observers (list of corda nodes)
+    - This solution has a late join problem
+- add support for async requests 
+- add support for request retries similaer to ethconnect
+- e2e integration with firefly
+- Add unit/integration tests and coverage 
+- Add acceptance tests
+
+
+
+
+
+ 
+
+
+

--- a/build.gradle
+++ b/build.gradle
@@ -9,6 +9,9 @@ repositories {
     mavenCentral()
 }
 
+sourceCompatibility = JavaVersion.VERSION_11
+targetCompatibility = JavaVersion.VERSION_11
+
 dependencies {
     testCompile group: 'junit', name: 'junit', version: '4.12'
 }

--- a/connector/build.gradle
+++ b/connector/build.gradle
@@ -12,13 +12,11 @@ buildscript {
 }
 
 plugins {
-    id 'io.spring.dependency-management' version '1.0.11.RELEASE'
-    id 'org.springframework.boot' version '2.0.2.RELEASE'
+    id 'org.springframework.boot' version '2.1.15.RELEASE'
 }
 
 
 repositories {
-    mavenLocal()
     jcenter()
     mavenCentral()
     maven { url 'https://jitpack.io' }
@@ -27,6 +25,7 @@ repositories {
 }
 
 apply plugin:'java'
+apply plugin: 'application'
 apply plugin: 'io.spring.dependency-management'
 apply plugin: 'org.springframework.boot'
 
@@ -38,25 +37,45 @@ dependencyManagement {
     }
 }
 
+// Corda serialization requires function parameter names to be included in the class file
+compileJava {
+    options.compilerArgs << '-parameters'
+}
+
 dependencies {
     // CorDapp dependencies
-    compile project(":cordapp:firefly-contracts")
-    compile project(":cordapp:firefly-flows")
+    implementation project(":cordapp:firefly-contracts")
+    implementation project(":cordapp:firefly-flows")
 
     testCompile "junit:junit:4.12"
 
     // Corda dependencies.
-    compile "net.corda:corda-core:$corda_release_version"
-    compile "net.corda:corda-jackson:$corda_release_version"
-    compile "net.corda:corda-rpc:$corda_release_version"
-    compile("org.springframework.boot:spring-boot-starter-websocket:2.0.2.RELEASE") {
+    implementation "net.corda:corda-core:$corda_release_version"
+    implementation "net.corda:corda-rpc:$corda_release_version"
+    implementation "net.corda:corda-jackson:$corda_release_version"
+    implementation 'javax.json:javax.json-api:1.0'
+
+    implementation("org.springframework.boot:spring-boot-starter-websocket:2.1.15.RELEASE") {
         exclude group: "org.springframework.boot", module: "spring-boot-starter-logging"
     }
-    compile "org.springframework.boot:spring-boot-starter-log4j2:2.0.2.RELEASE"
-    compile "org.springdoc:springdoc-openapi-ui:1.5.2"
-    compile "org.apache.logging.log4j:log4j-web:2.11.2"
+    implementation ("org.springframework.boot:spring-boot-starter-data-jpa:2.1.15.RELEASE") {
+        exclude group: "org.springframework.boot", module: "spring-boot-starter-logging"
+    }
+    implementation "org.springframework.boot:spring-boot-starter-log4j2:2.1.15.RELEASE"
+    implementation "org.springdoc:springdoc-openapi-ui:1.5.2"
+    implementation "org.apache.logging.log4j:log4j-web:2.11.2"
+    implementation "org.javassist:javassist:3.23.1-GA"
+    runtime "com.h2database:h2:1.4.200"
 }
+
+mainClassName = 'io.kaleido.cordaconnector.Server'
+
 
 springBoot {
     mainClassName = 'io.kaleido.cordaconnector.Server'
+}
+
+task deployFireflyServer(type: JavaExec, dependsOn: jar) {
+    classpath = sourceSets.main.runtimeClasspath
+    main = mainClassName
 }

--- a/connector/src/main/java/io/kaleido/cordaconnector/config/CordaRPCConfig.java
+++ b/connector/src/main/java/io/kaleido/cordaconnector/config/CordaRPCConfig.java
@@ -16,7 +16,10 @@
 
 package io.kaleido.cordaconnector.config;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import net.corda.client.jackson.JacksonSupport;
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
@@ -48,5 +51,18 @@ public class CordaRPCConfig {
 
     public void setPassword(String password) {
         this.password = password;
+    }
+
+    @Override
+    public String toString() {
+        return "CordaRPCConfig{" +
+                "host='" + host + '\'' +
+                ", username='" + username + '\'' +
+                '}';
+    }
+
+    @Bean
+    public ObjectMapper registerModule() {
+        return JacksonSupport.createNonRpcMapper();
     }
 }

--- a/connector/src/main/java/io/kaleido/cordaconnector/config/DataSourceConfig.java
+++ b/connector/src/main/java/io/kaleido/cordaconnector/config/DataSourceConfig.java
@@ -16,7 +16,11 @@
 
 package io.kaleido.cordaconnector.config;
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.jdbc.DataSourceBuilder;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+
+import javax.sql.DataSource;
 
 @Configuration
 @ConfigurationProperties("db")
@@ -56,5 +60,15 @@ public class DataSourceConfig {
 
     public void setPassword(String password) {
         this.password = password;
+    }
+
+    @Bean
+    public DataSource getDataSource() {
+        DataSourceBuilder dataSourceBuilder = DataSourceBuilder.create();
+        dataSourceBuilder.driverClassName(driverClassName);
+        dataSourceBuilder.url(url);
+        dataSourceBuilder.username(username);
+        dataSourceBuilder.password(password);
+        return dataSourceBuilder.build();
     }
 }

--- a/connector/src/main/java/io/kaleido/cordaconnector/config/SpringContext.java
+++ b/connector/src/main/java/io/kaleido/cordaconnector/config/SpringContext.java
@@ -13,13 +13,22 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
 package io.kaleido.cordaconnector.config;
 
-import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.context.annotation.Configuration;
+import org.springframework.beans.BeansException;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ApplicationContextAware;
+import org.springframework.stereotype.Component;
 
-@Configuration
-@ConfigurationProperties("db")
-public class EventStreamConfig {
+@Component
+public class SpringContext implements ApplicationContextAware {
+    private static ApplicationContext context;
+    @Override
+    public void setApplicationContext(ApplicationContext context) throws BeansException {
+        this.context = context;
+    }
+
+    public static ApplicationContext getApplicationContext() {
+        return context;
+    }
 }

--- a/connector/src/main/java/io/kaleido/cordaconnector/config/WebsocketConfig.java
+++ b/connector/src/main/java/io/kaleido/cordaconnector/config/WebsocketConfig.java
@@ -13,13 +13,16 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
 package io.kaleido.cordaconnector.config;
 
-import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.socket.server.standard.ServerEndpointExporter;
 
 @Configuration
-@ConfigurationProperties("db")
-public class EventStreamConfig {
+public class WebsocketConfig {
+    @Bean
+    public ServerEndpointExporter serverEndpointExporter() {
+        return new ServerEndpointExporter();
+    }
 }

--- a/connector/src/main/java/io/kaleido/cordaconnector/controller/EventStreamController.java
+++ b/connector/src/main/java/io/kaleido/cordaconnector/controller/EventStreamController.java
@@ -15,10 +15,91 @@
 // limitations under the License.
 
 package io.kaleido.cordaconnector.controller;
-
-import org.springframework.web.bind.annotation.RestController;
+import io.kaleido.cordaconnector.db.entity.EventStreamInfo;
+import io.kaleido.cordaconnector.db.entity.SubscriptionInfo;
+import io.kaleido.cordaconnector.model.request.ConnectorRequest;
+import io.kaleido.cordaconnector.model.response.ConnectorResponse;
+import io.kaleido.cordaconnector.model.common.EventStreamData;
+import io.kaleido.cordaconnector.model.common.SubscriptionData;
+import io.kaleido.cordaconnector.service.EventStreamService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.*;
+import java.util.List;
 
 @RestController
 public class EventStreamController {
+    @Autowired
+    private EventStreamService eventStreamService;
 
+    @PostMapping("/eventstreams")
+    public ConnectorResponse<EventStreamInfo> createEventStream(@RequestBody ConnectorRequest<EventStreamData> request) {
+        EventStreamInfo res = eventStreamService.createEventStream(request.getData());
+        return new ConnectorResponse<>(res);
+    }
+
+    @GetMapping("/eventstreams")
+    public ConnectorResponse<List<EventStreamInfo>> listEventStreams() {
+        List<EventStreamInfo> res = eventStreamService.listEventStreams();
+        return new ConnectorResponse<>(res);
+    }
+
+    @GetMapping("/eventstreams/{eventstream_id}")
+    public ConnectorResponse<EventStreamInfo> getEventStreamById(@PathVariable("eventstream_id") String eventstreamId) {
+        EventStreamInfo res = eventStreamService.getEventStreamById(eventstreamId);
+        return new ConnectorResponse<>(res);
+    }
+
+    @PatchMapping("/eventstreams/{eventstream_id}")
+    public ConnectorResponse<EventStreamInfo> updateEventStream(@PathVariable("eventstream_id") String eventstreamId, @RequestBody ConnectorRequest<EventStreamData> request) {
+        EventStreamInfo res = eventStreamService.updateEventStream(eventstreamId, request.getData());
+        return new ConnectorResponse<>(res);
+    }
+
+    @DeleteMapping("/eventstreams/{eventstream_id}")
+    public ConnectorResponse deleteEventStream(@PathVariable("eventstream_id") String eventstreamId) {
+        eventStreamService.deleteEventStream(eventstreamId);
+        return new ConnectorResponse();
+    }
+
+    @PostMapping("/eventstreams/{eventstream_id}/suspend")
+    public ConnectorResponse suspendEventStream(@PathVariable("eventstream_id") String eventstreamId) {
+        eventStreamService.suspendEventStream(eventstreamId);
+        return new ConnectorResponse();
+    }
+
+    @PostMapping("/eventstreams/{eventstream_id}/resume")
+    public ConnectorResponse resumeEventStream(@PathVariable("eventstream_id") String eventstreamId) {
+        eventStreamService.resumeEventStream(eventstreamId);
+        return new ConnectorResponse();
+    }
+
+    @PostMapping("/subscriptions")
+    public ConnectorResponse<SubscriptionInfo> createSubscription(@RequestBody ConnectorRequest<SubscriptionData> request) {
+        SubscriptionInfo res = eventStreamService.createSubscription(request.getData());
+        return new ConnectorResponse<>(res);
+    }
+
+    @GetMapping("/subscriptions")
+    public ConnectorResponse<List<SubscriptionInfo>> listSubscriptions() {
+        List<SubscriptionInfo> res = eventStreamService.listSubsciptions();
+        return new ConnectorResponse<>(res);
+    }
+
+    @GetMapping("/subscriptions/{subscription_id}")
+    public ConnectorResponse<SubscriptionInfo> getSubscriptionById(@PathVariable("subscription_id") String subscriptionId) {
+        SubscriptionInfo res = eventStreamService.getSubscriptionById(subscriptionId);
+        return new ConnectorResponse<>(res);
+    }
+
+    @DeleteMapping("/subscriptions/{subscription_id}")
+    public ConnectorResponse deleteSubscription(@PathVariable("subscription_id") String subscriptionId) {
+        eventStreamService.deleteSubscription(subscriptionId);
+        return new ConnectorResponse();
+    }
+
+    @PostMapping("/subscriptions/{subscription_id}/reset")
+    public ConnectorResponse resetSubscription(@PathVariable("subscription_id") String subscriptionId) {
+        eventStreamService.resetSubscription(subscriptionId);
+        return new ConnectorResponse();
+    }
 }

--- a/connector/src/main/java/io/kaleido/cordaconnector/controller/FireFlyController.java
+++ b/connector/src/main/java/io/kaleido/cordaconnector/controller/FireFlyController.java
@@ -17,23 +17,30 @@
 package io.kaleido.cordaconnector.controller;
 
 import io.kaleido.cordaconnector.exception.CordaConnectionException;
-import io.kaleido.cordaconnector.model.request.BroadcastBatchRequest;
+import io.kaleido.cordaconnector.model.request.ConnectorRequest;
+import io.kaleido.cordaconnector.model.common.BroadcastBatchData;
 import io.kaleido.cordaconnector.model.response.ConnectorResponse;
 import io.kaleido.cordaconnector.service.FireFlyService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.concurrent.ExecutionException;
 
 @RestController
 public class FireFlyController {
+    private static final Logger logger = LoggerFactory.getLogger(FireFlyController.class);
+
     @Autowired
     private FireFlyService fireFlyService;
 
     @PostMapping("/broadcastBatch")
-    public ConnectorResponse broadcastBatch(BroadcastBatchRequest request) throws CordaConnectionException, InterruptedException, ExecutionException {
-        String txHash = fireFlyService.broadcastBatch(request);
+    public ConnectorResponse<String> broadcastBatch(@RequestBody ConnectorRequest<BroadcastBatchData> request) throws CordaConnectionException, InterruptedException, ExecutionException {
+        String txHash = fireFlyService.broadcastBatch(request.getData());
+        logger.info("Request({}), broadcastBatch (batchID:{}, groupID:{}, payloadRef:{}) creation transaction {} was successful.", request.getId(), request.getData().getBatchId(), request.getData().getGroupId(), request.getData().getPayloadRef(),  txHash);
         return new ConnectorResponse(txHash);
     }
 

--- a/connector/src/main/java/io/kaleido/cordaconnector/db/IEventStreamRepository.java
+++ b/connector/src/main/java/io/kaleido/cordaconnector/db/IEventStreamRepository.java
@@ -14,12 +14,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package io.kaleido.cordaconnector.config;
+package io.kaleido.cordaconnector.db;
 
-import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.context.annotation.Configuration;
+import io.kaleido.cordaconnector.db.entity.EventStreamInfo;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
 
-@Configuration
-@ConfigurationProperties("db")
-public class EventStreamConfig {
+import java.util.stream.Stream;
+
+@Repository
+public interface IEventStreamRepository extends JpaRepository<EventStreamInfo, String> {
+    @Query("select e from EventStreamInfo e order by e.id asc")
+    Stream<EventStreamInfo> findAllStream();
 }

--- a/connector/src/main/java/io/kaleido/cordaconnector/db/ISubscriptionRepository.java
+++ b/connector/src/main/java/io/kaleido/cordaconnector/db/ISubscriptionRepository.java
@@ -1,0 +1,39 @@
+// Copyright © 2021 Kaleido, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package io.kaleido.cordaconnector.db;
+
+import io.kaleido.cordaconnector.db.entity.SubscriptionInfo;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+
+import java.util.stream.Stream;
+
+@Repository
+public interface ISubscriptionRepository extends JpaRepository<SubscriptionInfo, String> {
+
+    @Query("select id from SubscriptionInfo sub where sub.stream.id = ?1")
+    Stream<String> listSubscriptionIdsByEventStreamId(String eventStreamId);
+
+    @Query("select s from SubscriptionInfo s order by s.id asc")
+    Stream<SubscriptionInfo> findAllSubscriptions();
+
+    @Modifying
+    @Query("delete from SubscriptionInfo sub where sub.stream.id = ?1")
+    void deleteInBulkByEventStreamId(String eventStreamId);
+}

--- a/connector/src/main/java/io/kaleido/cordaconnector/db/entity/EventStreamInfo.java
+++ b/connector/src/main/java/io/kaleido/cordaconnector/db/entity/EventStreamInfo.java
@@ -16,7 +16,9 @@
 
 package io.kaleido.cordaconnector.db.entity;
 
-import io.kaleido.cordaconnector.model.response.data.ErrorHandling;
+import io.kaleido.cordaconnector.model.common.ErrorHandling;
+import io.kaleido.cordaconnector.model.common.EventStreamData;
+import io.kaleido.cordaconnector.service.EventStream;
 
 import javax.persistence.*;
 import javax.validation.constraints.Size;
@@ -68,5 +70,90 @@ public class EventStreamInfo implements Serializable {
     protected void onUpdate() {
         Date now = new Date();
         updated = new Timestamp(now.getTime());
+    }
+
+    public EventStreamInfo(String id, EventStreamData streamData) {
+        this.id = id;
+        this.name = streamData.getName();
+        this.batchSize = streamData.getBatchSize();
+        this.batchTimeoutMs = streamData.getBatchTimeoutMS();
+        this.batchRetryDelaySec = streamData.getBlockedRetryDelaySec();
+        this.errorHandling = streamData.getErrorHandling();
+        this.suspended = false;
+        this.websocketTopic = streamData.getWebsocket().getTopic();
+    }
+
+    public EventStreamInfo() {}
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public int getBatchSize() {
+        return batchSize;
+    }
+
+    public void setBatchSize(int batchSize) {
+        this.batchSize = batchSize;
+    }
+
+    public int getBatchTimeoutMs() {
+        return batchTimeoutMs;
+    }
+
+    public void setBatchTimeoutMs(int batchTimeoutMs) {
+        this.batchTimeoutMs = batchTimeoutMs;
+    }
+
+    public int getBatchRetryDelaySec() {
+        return batchRetryDelaySec;
+    }
+
+    public void setBatchRetryDelaySec(int batchRetryDelaySec) {
+        this.batchRetryDelaySec = batchRetryDelaySec;
+    }
+
+    public ErrorHandling getErrorHandling() {
+        return errorHandling;
+    }
+
+    public void setErrorHandling(ErrorHandling errorHandling) {
+        this.errorHandling = errorHandling;
+    }
+
+    public String getWebsocketTopic() {
+        return websocketTopic;
+    }
+
+    public void setWebsocketTopic(String websocketTopic) {
+        this.websocketTopic = websocketTopic;
+    }
+
+    public boolean isSuspended() {
+        return suspended;
+    }
+
+    public void setSuspended(boolean suspended) {
+        this.suspended = suspended;
+    }
+
+    public Timestamp getCreated() {
+        return created;
+    }
+
+    public Timestamp getUpdated() {
+        return updated;
     }
 }

--- a/connector/src/main/java/io/kaleido/cordaconnector/db/entity/SubscriptionInfo.java
+++ b/connector/src/main/java/io/kaleido/cordaconnector/db/entity/SubscriptionInfo.java
@@ -16,6 +16,7 @@
 
 package io.kaleido.cordaconnector.db.entity;
 
+import io.kaleido.cordaconnector.model.common.SubscriptionData;
 import net.corda.core.node.services.Vault;
 
 import javax.persistence.*;
@@ -25,7 +26,7 @@ import java.sql.Timestamp;
 import java.util.Date;
 
 @Entity
-@Table
+@Table(name = "subscriptions")
 public class SubscriptionInfo implements Serializable {
     @Id
     @Size(max = 39)
@@ -70,6 +71,90 @@ public class SubscriptionInfo implements Serializable {
     protected void onUpdate() {
         Date now = new Date();
         updated = new Timestamp(now.getTime());
+    }
+
+    public SubscriptionInfo(String id, SubscriptionData subscriptionData) {
+        this.id = id;
+        this.name = subscriptionData.getName();
+        this.stateStatus = subscriptionData.getFilter().getStateStatus();
+        this.relevancyStatus = subscriptionData.getFilter().getRelevancyStatus();
+        this.stateType = subscriptionData.getFilter().getStateType();
+        this.fromTime = Timestamp.from(subscriptionData.getFromTime());
+    }
+
+    public SubscriptionInfo() {}
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public EventStreamInfo getStream() {
+        return stream;
+    }
+
+    public void setStream(EventStreamInfo stream) {
+        this.stream = stream;
+    }
+
+    public String getStateType() {
+        return stateType;
+    }
+
+    public void setStateType(String stateType) {
+        this.stateType = stateType;
+    }
+
+    public Vault.StateStatus getStateStatus() {
+        return stateStatus;
+    }
+
+    public void setStateStatus(Vault.StateStatus stateStatus) {
+        this.stateStatus = stateStatus;
+    }
+
+    public Vault.RelevancyStatus getRelevancyStatus() {
+        return relevancyStatus;
+    }
+
+    public void setRelevancyStatus(Vault.RelevancyStatus relevancyStatus) {
+        this.relevancyStatus = relevancyStatus;
+    }
+
+    public Timestamp getFromTime() {
+        return fromTime;
+    }
+
+    public void setFromTime(Timestamp fromTime) {
+        this.fromTime = fromTime;
+    }
+
+    public Timestamp getLastCheckpoint() {
+        return lastCheckpoint;
+    }
+
+    public void setLastCheckpoint(Timestamp lastCheckpoint) {
+        this.lastCheckpoint = lastCheckpoint;
+    }
+
+    public Timestamp getCreated() {
+        return created;
+    }
+
+
+    public Timestamp getUpdated() {
+        return updated;
     }
 }
 

--- a/connector/src/main/java/io/kaleido/cordaconnector/exception/ConnectionExceptionHandler.java
+++ b/connector/src/main/java/io/kaleido/cordaconnector/exception/ConnectionExceptionHandler.java
@@ -22,10 +22,17 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 
+import java.util.NoSuchElementException;
+
 @ControllerAdvice
 public class ConnectionExceptionHandler {
     @ExceptionHandler(CordaConnectionException.class)
     public ResponseEntity<ConnectorResponse<String>> handleCordaException(CordaConnectionException e) {
         return new ResponseEntity<ConnectorResponse<String>>(new ConnectorResponse<String>(HttpStatus.CONFLICT.value(), false, e.getMessage(), null), HttpStatus.CONFLICT);
+    }
+
+    @ExceptionHandler(NoSuchElementException.class)
+    public ResponseEntity<ConnectorResponse<String>> handleNotFound(NoSuchElementException e) {
+        return new ResponseEntity<ConnectorResponse<String>>(new ConnectorResponse<String>(HttpStatus.CONFLICT.value(), false, e.getMessage(), null), HttpStatus.NOT_FOUND);
     }
 }

--- a/connector/src/main/java/io/kaleido/cordaconnector/model/common/BroadcastBatchData.java
+++ b/connector/src/main/java/io/kaleido/cordaconnector/model/common/BroadcastBatchData.java
@@ -14,18 +14,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package io.kaleido.cordaconnector.model.request;
-import net.corda.core.identity.Party;
+package io.kaleido.cordaconnector.model.common;
 import java.util.List;
 import java.util.UUID;
 
-public class BroadcastBatchRequest {
+public class BroadcastBatchData {
     private String batchId;
     private String payloadRef;
-    private List<Party> observers;
+    private List<String> observers;
     private UUID groupId;
 
-    public BroadcastBatchRequest() {
+    public BroadcastBatchData() {
     }
 
     public String getBatchId() {
@@ -44,11 +43,11 @@ public class BroadcastBatchRequest {
         this.payloadRef = payloadRef;
     }
 
-    public List<Party> getObservers() {
+    public List<String> getObservers() {
         return observers;
     }
 
-    public void setObservers(List<Party> observers) {
+    public void setObservers(List<String> observers) {
         this.observers = observers;
     }
 
@@ -58,5 +57,15 @@ public class BroadcastBatchRequest {
 
     public void setGroupId(UUID groupId) {
         this.groupId = groupId;
+    }
+
+    @Override
+    public String toString() {
+        return "BroadcastBatchData{" +
+                "batchId='" + batchId + '\'' +
+                ", payloadRef='" + payloadRef + '\'' +
+                ", observers=" + observers +
+                ", groupId=" + groupId +
+                '}';
     }
 }

--- a/connector/src/main/java/io/kaleido/cordaconnector/model/common/ErrorHandling.java
+++ b/connector/src/main/java/io/kaleido/cordaconnector/model/common/ErrorHandling.java
@@ -14,12 +14,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package io.kaleido.cordaconnector.config;
+package io.kaleido.cordaconnector.model.common;
 
-import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.context.annotation.Configuration;
-
-@Configuration
-@ConfigurationProperties("db")
-public class EventStreamConfig {
+public enum ErrorHandling {
+    BLOCK, SKIP;
 }

--- a/connector/src/main/java/io/kaleido/cordaconnector/model/common/Event.java
+++ b/connector/src/main/java/io/kaleido/cordaconnector/model/common/Event.java
@@ -1,0 +1,74 @@
+package io.kaleido.cordaconnector.model.common;
+
+import net.corda.core.contracts.StateRef;
+
+import java.time.Instant;
+
+public class Event<T> {
+    private T data;
+    private String subId;
+    private String signature;
+    private StateRef stateRef;
+    private Instant recordedTime;
+    private Instant consumedTime;
+    public Event(){
+
+    }
+
+    public Event(T data, String subId, String signature, StateRef stateRef, Instant recordedTime, Instant consumedTime) {
+        this.data = data;
+        this.subId = subId;
+        this.signature = signature;
+        this.stateRef = stateRef;
+        this.recordedTime = recordedTime;
+        this.consumedTime = consumedTime;
+    }
+
+    public T getData() {
+        return data;
+    }
+
+    public void setData(T data) {
+        this.data = data;
+    }
+
+    public String getSubId() {
+        return subId;
+    }
+
+    public void setSubId(String subId) {
+        this.subId = subId;
+    }
+
+    public String getSignature() {
+        return signature;
+    }
+
+    public void setSignature(String signature) {
+        this.signature = signature;
+    }
+
+    public StateRef getStateRef() {
+        return stateRef;
+    }
+
+    public void setStateRef(StateRef stateRef) {
+        this.stateRef = stateRef;
+    }
+
+    public Instant getRecordedTime() {
+        return recordedTime;
+    }
+
+    public void setRecordedTime(Instant recordedTime) {
+        this.recordedTime = recordedTime;
+    }
+
+    public Instant getConsumedTime() {
+        return consumedTime;
+    }
+
+    public void setConsumedTime(Instant consumedTime) {
+        this.consumedTime = consumedTime;
+    }
+}

--- a/connector/src/main/java/io/kaleido/cordaconnector/model/common/EventStreamData.java
+++ b/connector/src/main/java/io/kaleido/cordaconnector/model/common/EventStreamData.java
@@ -1,0 +1,78 @@
+// Copyright © 2021 Kaleido, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package io.kaleido.cordaconnector.model.common;
+
+public class EventStreamData {
+    private String name;
+    private int batchSize=1;
+    private int batchTimeoutMS=5000;
+    private int blockedRetryDelaySec=30;
+
+    private ErrorHandling errorHandling = ErrorHandling.BLOCK;
+    private WebsocketData websocket;
+
+    public EventStreamData() {
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public int getBatchSize() {
+        return batchSize;
+    }
+
+    public void setBatchSize(int batchSize) {
+        this.batchSize = batchSize;
+    }
+
+    public int getBatchTimeoutMS() {
+        return batchTimeoutMS;
+    }
+
+    public void setBatchTimeoutMS(int batchTimeoutMS) {
+        this.batchTimeoutMS = batchTimeoutMS;
+    }
+
+    public int getBlockedRetryDelaySec() {
+        return blockedRetryDelaySec;
+    }
+
+    public void setBlockedRetryDelaySec(int blockedRetryDelaySec) {
+        this.blockedRetryDelaySec = blockedRetryDelaySec;
+    }
+
+    public ErrorHandling getErrorHandling() {
+        return errorHandling;
+    }
+
+    public void setErrorHandling(ErrorHandling errorHandling) {
+        this.errorHandling = errorHandling;
+    }
+
+    public WebsocketData getWebsocket() {
+        return websocket;
+    }
+
+    public void setWebsocket(WebsocketData websocket) {
+        this.websocket = websocket;
+    }
+}

--- a/connector/src/main/java/io/kaleido/cordaconnector/model/common/StateFilter.java
+++ b/connector/src/main/java/io/kaleido/cordaconnector/model/common/StateFilter.java
@@ -1,0 +1,52 @@
+// Copyright © 2021 Kaleido, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package io.kaleido.cordaconnector.model.common;
+
+import net.corda.core.node.services.Vault;
+
+public class StateFilter {
+    private String stateType;
+    private Vault.StateStatus stateStatus = Vault.StateStatus.ALL;
+    private Vault.RelevancyStatus relevancyStatus = Vault.RelevancyStatus.ALL;
+
+    public StateFilter() {
+    }
+
+    public String getStateType() {
+        return stateType;
+    }
+
+    public void setStateType(String stateType) {
+        this.stateType = stateType;
+    }
+
+    public Vault.StateStatus getStateStatus() {
+        return stateStatus;
+    }
+
+    public void setStateStatus(Vault.StateStatus stateStatus) {
+        this.stateStatus = stateStatus;
+    }
+
+    public Vault.RelevancyStatus getRelevancyStatus() {
+        return relevancyStatus;
+    }
+
+    public void setRelevancyStatus(Vault.RelevancyStatus relevancyStatus) {
+        this.relevancyStatus = relevancyStatus;
+    }
+}

--- a/connector/src/main/java/io/kaleido/cordaconnector/model/common/SubscriptionData.java
+++ b/connector/src/main/java/io/kaleido/cordaconnector/model/common/SubscriptionData.java
@@ -1,0 +1,60 @@
+// Copyright © 2021 Kaleido, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package io.kaleido.cordaconnector.model.common;
+import java.time.Instant;
+
+public class SubscriptionData {
+    private Instant fromTime;
+    private String stream;
+    private StateFilter filter;
+    private String name;
+
+    public SubscriptionData() {
+    }
+
+    public Instant getFromTime() {
+        return fromTime;
+    }
+
+    public void setFromTime(Instant fromTime) {
+        this.fromTime = fromTime;
+    }
+
+    public String getStream() {
+        return stream;
+    }
+
+    public void setStream(String stream) {
+        this.stream = stream;
+    }
+
+    public StateFilter getFilter() {
+        return filter;
+    }
+
+    public void setFilter(StateFilter filter) {
+        this.filter = filter;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+}

--- a/connector/src/main/java/io/kaleido/cordaconnector/model/common/WebsocketData.java
+++ b/connector/src/main/java/io/kaleido/cordaconnector/model/common/WebsocketData.java
@@ -14,12 +14,20 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package io.kaleido.cordaconnector.config;
+package io.kaleido.cordaconnector.model.common;
 
-import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.context.annotation.Configuration;
+public class WebsocketData {
+    private String topic;
 
-@Configuration
-@ConfigurationProperties("db")
-public class EventStreamConfig {
+    public WebsocketData() {
+
+    }
+
+    public String getTopic() {
+        return topic;
+    }
+
+    public void setTopic(String topic) {
+        this.topic = topic;
+    }
 }

--- a/connector/src/main/java/io/kaleido/cordaconnector/model/request/ConnectorRequest.java
+++ b/connector/src/main/java/io/kaleido/cordaconnector/model/request/ConnectorRequest.java
@@ -14,12 +14,30 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package io.kaleido.cordaconnector.config;
+package io.kaleido.cordaconnector.model.request;
 
-import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.context.annotation.Configuration;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
-@Configuration
-@ConfigurationProperties("db")
-public class EventStreamConfig {
+import java.util.UUID;
+
+@JsonIgnoreProperties("id")
+public class ConnectorRequest<T> {
+    private T data;
+    private String id;
+
+    public ConnectorRequest() {
+        this.id = UUID.randomUUID().toString();
+    }
+
+    public T getData() {
+        return data;
+    }
+
+    public void setData(T data) {
+        this.data = data;
+    }
+
+    public String getId() {
+        return id;
+    }
 }

--- a/connector/src/main/java/io/kaleido/cordaconnector/model/response/ConnectorResponse.java
+++ b/connector/src/main/java/io/kaleido/cordaconnector/model/response/ConnectorResponse.java
@@ -43,4 +43,36 @@ public class ConnectorResponse<T> {
         this.message = message;
         this.data = data;
     }
+
+    public int getStatusCode() {
+        return statusCode;
+    }
+
+    public void setStatusCode(int statusCode) {
+        this.statusCode = statusCode;
+    }
+
+    public boolean isStatus() {
+        return status;
+    }
+
+    public void setStatus(boolean status) {
+        this.status = status;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public void setMessage(String message) {
+        this.message = message;
+    }
+
+    public T getData() {
+        return data;
+    }
+
+    public void setData(T data) {
+        this.data = data;
+    }
 }

--- a/connector/src/main/java/io/kaleido/cordaconnector/rpc/NodeRPCClient.java
+++ b/connector/src/main/java/io/kaleido/cordaconnector/rpc/NodeRPCClient.java
@@ -28,6 +28,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+import rx.Observable;
 import rx.subjects.PublishSubject;
 
 import javax.annotation.PreDestroy;
@@ -42,9 +43,13 @@ public class NodeRPCClient {
 
     @Autowired
     public NodeRPCClient(CordaRPCConfig config) {
+        logger.info(config.toString());
         rpcConfig = config;
         connectionRx = PublishSubject.create();
+    }
 
+    public Observable<Boolean> getRpcConnectionObservable() {
+        return connectionRx.asObservable();
     }
 
     public CordaRPCOps getRpcProxy() throws CordaConnectionException {

--- a/connector/src/main/java/io/kaleido/cordaconnector/service/EventStream.java
+++ b/connector/src/main/java/io/kaleido/cordaconnector/service/EventStream.java
@@ -1,0 +1,316 @@
+// Copyright © 2021 Kaleido, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package io.kaleido.cordaconnector.service;
+
+import io.kaleido.cordaconnector.db.entity.EventStreamInfo;
+import io.kaleido.cordaconnector.model.common.ErrorHandling;
+import io.kaleido.cordaconnector.model.common.Event;
+import io.kaleido.cordaconnector.rpc.NodeRPCClient;
+import io.kaleido.cordaconnector.ws.WebSocketConnection;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import javax.websocket.EncodeException;
+import java.io.IOException;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.*;
+import java.util.concurrent.atomic.AtomicLong;
+
+public class EventStream {
+    public static final int MAX_BATCH_SIZE = 1000;
+    @Autowired
+    private NodeRPCClient rpcClient;
+    private EventStreamInfo eventStreamInfo;
+    // Information about eventstream that is persisted to database
+    private static final Logger log = LoggerFactory.getLogger(EventStream.class);
+    private final ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(1);
+    // Ongoing batch thread should not compete with other tasks, so we have a separate scheduler for the inFlightTask
+    private final ScheduledExecutorService inFlightScheduler = Executors.newSingleThreadScheduledExecutor();
+    // Batch timeout task is used for batch processing,
+    // It is canceled and rescheduled to execute after batchTimeout time, whenever new batch of events begin processing
+    // If executed, push whatever batch size we have available to a client
+    private ScheduledFuture<?> batchTimeoutTask;
+    // Task to keep track of ongoing push of current batch to a client with retries
+    private ScheduledFuture<?> inFlightTask;
+    // thread safe buffer of batches, ready to be pushed to clients
+    // TODO set buffer size limit?
+    private BlockingQueue<List<Event<?>>> eventBatchBuffer;
+    // active client connections consuming batches of events,
+    // events are pushed to clients in round robin fashion.
+    // an eventstream can have multiple consumers for load-balancing reason
+    private BlockingQueue<WebSocketConnection> activeConnections;
+    // current batch of events, it is added to buffer whenever batch size is reached
+    // or batchTimeout expires, whichever happens 1st
+    private BlockingQueue<Event<?>> currentBatch;
+    // Semaphore used to make sure batches of events are pushed one by one
+    // Acquired by a thread when it starts attempts with retries to push a batch to the client
+    // Released when a ack is received, or when we have SKIP error handling and an error is received
+    // Consumer application is responsible for not sending duplicate acks
+    private Semaphore inFlightLock;
+
+    public long getBatchCount() {
+        return batchCount.get();
+    }
+
+    // Volatile, used for debug logging
+    private AtomicLong batchCount = new AtomicLong(0);
+    // Map of subscription id to acked hwm.
+    private ConcurrentHashMap<String, Instant> subscriptionCheckpoints;
+
+    public EventStream(EventStreamInfo eventStreamInfo) {
+        this.eventStreamInfo = eventStreamInfo;
+        this.currentBatch = new LinkedBlockingQueue<>();
+        this.eventBatchBuffer = new LinkedBlockingQueue<>();
+        this.activeConnections = new LinkedBlockingQueue<>();
+        this.inFlightLock = new Semaphore(1);
+        this.subscriptionCheckpoints = new ConcurrentHashMap<>();
+    }
+
+    public EventStreamInfo getEventStreamInfo() {
+        return eventStreamInfo;
+    }
+
+    public void setEventStreamInfo(EventStreamInfo eventStreamInfo) {
+        this.eventStreamInfo = eventStreamInfo;
+    }
+
+    public void addStreamConsumer(WebSocketConnection connection) {
+        log.info("{}, Adding stream consumer client with connection id {}", eventStreamInfo.getId(), connection.getId());
+        activeConnections.add(connection);
+        _dispatchInQueueBatches();
+    }
+
+    public Map<String, Instant> getLatestCheckpoints() {
+        Map<String, Instant> checkpoints = Map.copyOf(this.subscriptionCheckpoints);
+        return checkpoints;
+    }
+
+    private void _dispatchInQueueBatches() {
+        // if there are batches in buffer waiting to be delivered, start dispatch if no new batch is in process
+        if(this.eventBatchBuffer.isEmpty() ) {
+            // cancel any running batch retries as we received the ack
+            // when there are events in the buffer, next batch will cancel previous retry task;
+            cancelInFlightBatch();
+        }
+        // dispatch next batch in the buffer
+        scheduler.submit(this::dispatchBatch);
+    }
+
+    public void onAck() {
+        log.debug("{} ack received. releasing in flight lock to allow next batch push.", eventStreamInfo.getId());
+        if(!eventBatchBuffer.isEmpty()) eventBatchBuffer.remove();
+        inFlightLock.release();
+        _dispatchInQueueBatches();
+    }
+
+    public void onError(String connectionId) {
+        log.debug("{} received error on connection with id: {}", eventStreamInfo.getId(), connectionId);
+        if(eventStreamInfo.getErrorHandling() == ErrorHandling.SKIP) {
+            log.debug("{} SKIP error handler, releasing in flight lock to allow next batch push.", eventStreamInfo.getId());
+            if(!eventBatchBuffer.isEmpty()) eventBatchBuffer.remove();
+            inFlightLock.release();
+            _dispatchInQueueBatches();
+        } else {
+            log.debug("{} BLOCK error handler", eventStreamInfo.getId());
+        }
+    }
+
+    public void clearCheckpoints() {
+        log.info("{} clearing checkpoints for all subscriptions", eventStreamInfo.getId());
+        subscriptionCheckpoints.clear();
+    }
+
+    public void onSuspend() {
+        // cancel any ongoing batch push, release locks and clear buffers.
+        // subscriptions will take care of restarting from appropriate time based on persisted checkpoints
+        log.info("{} suspending stream", eventStreamInfo.getId());
+        eventStreamInfo.setSuspended(true);
+        if(inFlightTask != null) inFlightTask.cancel(true);
+        inFlightLock.release();
+        eventBatchBuffer.clear();
+        currentBatch.clear();
+    }
+
+    public void onResume() {
+        log.info("{} Resuming stream", eventStreamInfo.getId());
+        eventStreamInfo.setSuspended(false);
+    }
+
+    private void onBatchTimeoutExpiry() {
+        // batch timeout expired, we should push if push the new batch if we have some events
+        log.trace("{} batch timeout expired.", eventStreamInfo.getId());
+        if(currentBatch.size() > 0) {
+            log.debug("{} On batchTimeout expiry, pushing new batch with {} events, batch size {}", eventStreamInfo.getId(), currentBatch.size(), eventStreamInfo.getBatchSize());
+            onBatchComplete();
+        } else if(eventBatchBuffer.size() > 0) {
+            scheduler.submit(this::dispatchBatch);
+        }
+    }
+
+    private void onBatchComplete() {
+        log.trace("{} On Batch completed.",eventStreamInfo.getId());
+        List<Event<?>> batch = new ArrayList<>();
+        currentBatch.drainTo(batch);
+        if(batch.size() > 0) {
+            eventBatchBuffer.add(batch);
+            log.debug("{} On Batch completed. sending new batch",eventStreamInfo.getId());
+            scheduler.submit(this::dispatchBatch);
+        }
+    }
+
+    /*
+     * Used by Upstream subscription to push events as they arrive. New events are ignored of stream is suspended.
+     * Triggers the batch processing logic, i.e., adds the event to current batch or start a batchtimeout timer if
+     * starting a new batch or starts dispatch if current batch is complete. Blocks if current batch is full and not
+     * dispatched.
+     * */
+    public void pushNewEvent(Event<?> vaultEvent) {
+        log.debug("{} Received new event for batch processing",eventStreamInfo.getId());
+        if(eventStreamInfo.isSuspended()) {
+            log.debug("{} Ignoring event as stream is suspended",eventStreamInfo.getId());
+            return;
+        }
+        if(currentBatch.size() == 0) {
+            log.debug("{} Starting new batch of event and batchTimeout task",eventStreamInfo.getId());
+            batchTimeoutTask = scheduler.schedule(() -> onBatchTimeoutExpiry(), eventStreamInfo.getBatchTimeoutMs(), TimeUnit.MILLISECONDS);
+        }
+
+        if(currentBatch.size() < eventStreamInfo.getBatchSize()-1) {
+            log.debug("{} current batch size {}, batch size {}",eventStreamInfo.getId(), currentBatch.size()+1, eventStreamInfo.getBatchSize());
+            currentBatch.add(vaultEvent);
+        } else if(currentBatch.size() == eventStreamInfo.getBatchSize()-1){
+            batchTimeoutTask.cancel(true);
+            currentBatch.add(vaultEvent);
+            log.debug("{} Batch completed. cancelling batchTimeoutTask, size {}",eventStreamInfo.getId(), currentBatch.size());
+            onBatchComplete();
+        } else {
+            // batch is full, queue add task
+            log.debug("{} Batch full. blocking until batch is queued for dispatch", eventStreamInfo.getId());
+            onBatchComplete();
+            pushNewEvent(vaultEvent);
+        }
+    }
+
+
+
+    /*
+     *  Attempts to send a batch from queued batches. Inflight lock ensures that only one batch (front of queue) is in-flight at a time.
+     *  After acquiring inflight lock, we cancel old inflight task if it is running. Update future checkpoints of subscriptions (values that will be checkpointed
+     *  when ack is received for this eventstream. The inflihgt lock is released upon receipt of an ack or an error (if SKIP errorhandling) and front of batch buffer is removed,
+     *  to allow next batch of event to be disptached. The inflight lock can also be released if there are no batches to send or eventstream is suspended or
+     *  no active consumers of the stream.
+     * */
+
+    private void dispatchBatch(){
+        log.debug("{} Start dispatching new batch",eventStreamInfo.getId());
+        try {
+            log.trace("{} acquiring lock for batch {}...", eventStreamInfo.getId(), batchCount.get()+1);
+            inFlightLock.acquire();
+            log.trace("{} acquired lock for batch {}...", eventStreamInfo.getId(), batchCount.get()+1);
+        } catch (InterruptedException e) {
+            log.error("{}, error while sending batch {}", eventStreamInfo.getId(), batchCount.get()+1, e);
+        }
+        if (inFlightTask != null && !inFlightTask.isCancelled()) {
+            log.debug("{} cancelling old inflight task", eventStreamInfo.getId());
+            inFlightTask.cancel(true);
+        }
+        if (eventStreamInfo.isSuspended()) {
+            log.debug("{} is suspended, abort send of batch {}", eventStreamInfo.getId(), batchCount.get()+1);
+            inFlightLock.release();
+            return;
+        }
+        if(this.activeConnections.isEmpty()) {
+            log.debug("{} Aborting dispatch of batch {}, no active consumers of the stream", eventStreamInfo.getId(), batchCount.get()+1);
+            inFlightLock.release();
+            return;
+        }
+        if(this.eventBatchBuffer.isEmpty()) {
+            log.debug("{} Aborting dispatch, no batch available to dispatch", eventStreamInfo.getId());
+            inFlightLock.release();
+            return;
+        }
+        attemptBatchWithRetry(this.eventBatchBuffer.peek(), batchCount.incrementAndGet());
+    }
+
+    private void _updateCheckpoint(String subscriptionId, Instant time){
+        Instant oldCheckpoint = subscriptionCheckpoints.get(subscriptionId);
+        if(oldCheckpoint == null || time.isAfter(oldCheckpoint)) {
+            log.info("{} updating checkpoint for the subscription {}, new {}, old {}", eventStreamInfo.getId() ,subscriptionId, time, oldCheckpoint);
+            subscriptionCheckpoints.put(subscriptionId, time);
+        }
+    }
+
+    /*
+     * Next batch attempt clears previous inflight task. If there are no more batches to send, this task can be queued on receipt of ack
+     * or error (SKIP handling) to cancel inflight task. We simply release the lock after cancelling the task to allow new batch of events.
+     * */
+    private void cancelInFlightBatch() {
+        scheduler.submit(() -> {
+            try {
+                log.trace("{} acquiring lock for cancelling inflight task...", eventStreamInfo.getId());
+                inFlightLock.acquire();
+                log.trace("{} acquired lock for cancelling inflight task...", eventStreamInfo.getId());
+                if(inFlightTask != null && !inFlightTask.isCancelled()) {
+                    log.info("{} cancelling old inflight task", eventStreamInfo.getId());
+                    inFlightTask.cancel(true);
+                }
+                inFlightLock.release();
+            } catch (InterruptedException e) {
+                log.error("{}, error while cancelling inflight task... {}", eventStreamInfo.getId(), batchCount, e);
+            }
+        });
+    }
+
+    /*
+     *  Updates future checkpoints for all subscription based on events in the batch.
+     *  Schedules a periodic task (InflightTask) to send data to active consumers of this eventstream,
+     *  Inflight task attempts to send data to active consumers after every blockedRetryDelaySec.
+     *  Inflight task would be cancelled if ack/ error(SKIP handling) is received from a consumer
+     * */
+    private void attemptBatchWithRetry(List<Event<?>> batch, long batchCount) {
+        log.debug("{} sending batch {} to clients",eventStreamInfo.getId(), batchCount);
+        // update checkpoints, before attempting new send
+        batch.forEach(event -> {
+            Instant update = event.getConsumedTime()!=null?event.getConsumedTime():event.getRecordedTime();
+            _updateCheckpoint(event.getSubId(), update);
+        });
+        log.debug("{} setting new inflight task for batch {}", eventStreamInfo.getId(), batchCount);
+        inFlightTask = inFlightScheduler.scheduleWithFixedDelay(() -> {
+            //round robin scheduling
+            WebSocketConnection connection = null;
+            log.trace("{} active connection size {}", eventStreamInfo.getId(), activeConnections.size());
+            do {
+                // remove closed/inactive connection
+                if(this.activeConnections.size() == 0) return;
+                connection = this.activeConnections.remove();
+            } while (!connection.isOpen());
+            //add to back of the queue again.
+            this.activeConnections.add(connection);
+            log.trace("{} trying connection with id {}", eventStreamInfo.getId(), connection.getId());
+            try {
+                connection.sendData(batch);
+                log.info("Sent batch {} to client {}", batchCount, connection.getId());
+            } catch (IOException | EncodeException e ) {
+                log.error("{}, error while sending batch {} to client {}", eventStreamInfo.getId(), batchCount, connection.getId(), e);
+            }
+        }, 100, this.eventStreamInfo.getBatchRetryDelaySec()*1000, TimeUnit.MILLISECONDS);
+    }
+}

--- a/connector/src/main/java/io/kaleido/cordaconnector/service/EventStream.java
+++ b/connector/src/main/java/io/kaleido/cordaconnector/service/EventStream.java
@@ -311,6 +311,6 @@ public class EventStream {
             } catch (IOException | EncodeException e ) {
                 log.error("{}, error while sending batch {} to client {}", eventStreamInfo.getId(), batchCount, connection.getId(), e);
             }
-        }, 100, this.eventStreamInfo.getBatchRetryDelaySec()*1000, TimeUnit.MILLISECONDS);
+        }, 100, this.eventStreamInfo.getBatchRetryDelaySec()* 1000L, TimeUnit.MILLISECONDS);
     }
 }

--- a/connector/src/main/java/io/kaleido/cordaconnector/service/EventStreamService.java
+++ b/connector/src/main/java/io/kaleido/cordaconnector/service/EventStreamService.java
@@ -16,17 +16,428 @@
 
 package io.kaleido.cordaconnector.service;
 
+import io.kaleido.cordaconnector.db.IEventStreamRepository;
+import io.kaleido.cordaconnector.db.ISubscriptionRepository;
+import io.kaleido.cordaconnector.db.entity.EventStreamInfo;
+import io.kaleido.cordaconnector.db.entity.SubscriptionInfo;
+import io.kaleido.cordaconnector.exception.CordaConnectionException;
+import io.kaleido.cordaconnector.model.common.EventStreamData;
+import io.kaleido.cordaconnector.model.common.SubscriptionData;
+import io.kaleido.cordaconnector.rpc.NodeRPCClient;
+import io.kaleido.cordaconnector.ws.ClientMessage;
+import io.kaleido.cordaconnector.ws.WebSocketConnection;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import javax.transaction.Transactional;
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 @Service
 public class EventStreamService {
-    private static EventStreamService _instance;
-    public static EventStreamService getInstance() {
-        if(_instance == null) {
-            _instance = new EventStreamService();
-        }
-        return  _instance;
+    private static final Logger logger = LoggerFactory.getLogger(EventStreamService.class);
+    private static final ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(1);
+    @Autowired
+    private NodeRPCClient rpcClient;
+    @Autowired
+    private IEventStreamRepository eventStreamRepository;
+    @Autowired
+    private ISubscriptionRepository subscriptionRepository;
+    private Map<String, WebSocketConnection> webSocketConnectionMap;
+    // Map of subscription id to runtime subscription object
+    private ConcurrentHashMap<String, Subscription> subscriptions;
+    private ConcurrentHashMap<String, String> topicToEventStreamId;
+    // Map of stream Id to runtime stream object
+    private ConcurrentHashMap<String, EventStream> streams;
+    public EventStreamService() {
+        this.streams = new ConcurrentHashMap<>();
+        this.subscriptions = new ConcurrentHashMap<>();
+        this.webSocketConnectionMap = new HashMap<>();
+        this.topicToEventStreamId = new ConcurrentHashMap<>();
+        scheduler.submit(() -> {
+            boolean connectionEstablished=false;
+            long waitBeforeRetry = 1000;
+            long delayMultiplier = 2;
+            long retries = 0;
+            long maxRetries= 10;
+            while(!connectionEstablished) {
+                try {
+                    rpcClient.getRpcProxy();
+                    connectionEstablished = true;
+                } catch (CordaConnectionException e) {
+                    logger.info("Failed to connect to corda on EventStreamService startup. retrying attempt {}", retries, e);
+                }
+                if(retries == maxRetries) {
+                    logger.error("Failed to connect to corda on EventStreamService startup after {} attempts, exiting.", maxRetries);
+                    System.exit(1);
+                }
+                waitBeforeRetry *= delayMultiplier;
+                retries++;
+                if(!connectionEstablished) {
+                    try {
+                        Thread.sleep(waitBeforeRetry);
+                    } catch (InterruptedException e) {
+                        logger.error("Thread interrupted while waiting before retrying.", e);
+                    }
+                }
+            }
+            // setup observer for corda rpc connection changes
+            rpcClient.getRpcConnectionObservable().subscribe((isConnected) -> {
+                if(isConnected) onCordaRpcConnect();
+                else onCordaRpcDisconnect();
+            });
+            restoreStreamsFromDb();
+            restoreSubscriptionsFromDb();
+        });
     }
-    private EventStreamService() {
+
+    private void restoreStreamsFromDb() {
+        logger.info("Restoring streams from database.");
+        eventStreamRepository.findAllStream().forEach(this::_createOrUpdateStream);
+    }
+    private void restoreSubscriptionsFromDb() {
+        logger.info("Restoring subscriptions from database.");
+        subscriptionRepository.findAllSubscriptions().forEach(this::_createOrResetSubscription);
+    }
+
+    private void onCordaRpcDisconnect() {
+        // pause all subscriptions
+        logger.info("Corda rpc disconnect detected, pausing subscriptions.");
+        subscriptions.forEachValue(5, Subscription::pauseSubscription);
+    }
+
+    private void onCordaRpcConnect() {
+        // resume all subscriptions
+        logger.info("Corda rpc reconnect detected, resuming subscriptions.");
+        subscriptions.forEachValue(5, subscription -> {
+            if(subscription.isPaused()) {
+                subscription.resumeSubscription();
+            }
+        });
+    }
+
+    private EventStream getEventStreamByTopic(String topic) throws Exception {
+        String eventStreamId = this.topicToEventStreamId.get(topic);
+        EventStream stream = this.streams.get(eventStreamId);
+        if(stream == null) {
+            throw new Exception("No stream with topic "+topic+" exists", null);
+        }
+        return stream;
+    }
+
+    private void checkPointSubscription(Subscription sub) {
+        SubscriptionInfo subscriptionInfo = sub.getSubscriptionInfo();
+        logger.info("{} Persisting current HWM {}", subscriptionInfo.getId(), sub.getTimeHWM());
+        Timestamp lastCheckpoint = subscriptionInfo.getLastCheckpoint();
+        try {
+            if(lastCheckpoint == null || sub.getTimeHWM() != null && sub.getTimeHWM().isAfter(lastCheckpoint.toInstant())) {
+                subscriptionInfo.setLastCheckpoint(Timestamp.from(sub.getTimeHWM()));
+                subscriptionRepository.save(subscriptionInfo);
+            }
+        } catch (Exception e) {
+            logger.error("{} failed to persist current HWM {}", subscriptionInfo.getId(), sub.getTimeHWM(), e);
+            subscriptionInfo.setLastCheckpoint(lastCheckpoint);
+        }
+    }
+
+    private void handleAck(EventStream stream) {
+        logger.debug("Handling ack for the eventstream {}", stream.getEventStreamInfo().getId());
+        Map<String, Instant> checkpointMap = stream.getLatestCheckpoints();
+        checkpointMap.forEach((subscriptionId, checkpoint) -> {
+            Subscription subscription = this.subscriptions.get(subscriptionId);
+            if(subscription != null) {
+                logger.debug("Subscription {}, checkpointing", subscriptionId);
+                subscription.setTimeHWM(checkpoint);
+                checkPointSubscription(subscription);
+            } else {
+                logger.debug("Subscription {} not found, skipping checkpointing", subscriptionId);
+            }
+        });
+        stream.onAck();
+    }
+
+    public void addWebSocketConnection(WebSocketConnection connection) {
+        this.webSocketConnectionMap.put(connection.getId(), connection);
+    }
+
+    public void removeWebSocketConnection(String connectionId) {
+        //Just Removes connections from service
+        //closed connections from eventstream object are removed lazily, (when trying to push events)
+        this.webSocketConnectionMap.remove(connectionId);
+    }
+
+    public void onWebSocketMessage(String connectionId, ClientMessage message) {
+        scheduler.submit(() ->{
+            WebSocketConnection conn = webSocketConnectionMap.get(connectionId);
+            String topic = message.getTopic();
+            EventStream eventStream = null;
+            try {
+                eventStream = getEventStreamByTopic(topic);
+            } catch (Exception e) {
+                logger.error("Received message from client {} on topic {} for which eventstream doesn't exists", connectionId, topic, e);
+            }
+            switch(message.getType()) {
+                case LISTEN:
+                    // add connection to eventstream, eventstream will push events to conn as they are available
+                    eventStream.addStreamConsumer(conn);
+                    break;
+                case ACK:
+                    handleAck(eventStream);
+                    break;
+                case ERROR:
+                    eventStream.onError(conn.getId());
+                    break;
+            }
+        });
+    }
+
+    private void _createOrUpdateStream(EventStreamInfo eventStreamInfo) {
+        EventStream eventStream = this.streams.get(eventStreamInfo.getId());
+        if(eventStream == null) {
+            eventStream = new EventStream(eventStreamInfo);
+        } else {
+            eventStream.setEventStreamInfo(eventStreamInfo);
+        }
+        this.streams.put(eventStreamInfo.getId(), eventStream);
+        this.topicToEventStreamId.put(eventStreamInfo.getWebsocketTopic(), eventStreamInfo.getId());
+    }
+
+    private void _suspendStream(String eventstreamId) {
+        EventStream eventStream = this.streams.get(eventstreamId);
+        if(eventStream != null) {
+            // when stream is suspended, checkpoint and pause all subscriptions that push events to the stream
+            Map<String, Instant> checkpointMap = eventStream.getLatestCheckpoints();
+            checkpointMap.forEach((subscriptionId, checkpoint) -> {
+                Subscription subscription = this.subscriptions.get(subscriptionId);
+                if(subscription != null) {
+                    subscription.setTimeHWM(checkpoint);
+                    checkPointSubscription(subscription);
+                    subscription.pauseSubscription();
+                }
+            });
+            eventStream.onSuspend();
+        }
+
+    }
+
+    private void _resumeStream(String eventstreamId) {
+        EventStream eventStream = this.streams.get(eventstreamId);
+        if(eventStream != null) {
+            eventStream.onResume();
+            this.subscriptions.forEachValue(5, subscription -> {
+                if(subscription.getStream().getEventStreamInfo().getId().equalsIgnoreCase(eventstreamId)) subscription.resumeSubscription();
+            });
+        }
+    }
+
+    private void _deleteSubscription(String subscriptionId) {
+        // clean up subscription runtime
+        Subscription subscription = this.subscriptions.get(subscriptionId);
+        if(subscription != null) {
+            subscription.pauseSubscription();
+            this.subscriptions.remove(subscriptionId);
+        }
+    }
+
+    private void _deleteStream(String eventstreamId) {
+        // clean up stream runtime
+        EventStream stream = this.streams.get(eventstreamId);
+        if(stream != null) {
+            stream.onSuspend();
+            this.streams.remove(eventstreamId);
+        }
+    }
+
+    @Transactional
+    public EventStreamInfo createEventStream(EventStreamData streamData) {
+        String id = "es-"+ UUID.randomUUID().toString();
+        Optional<EventStreamInfo> existingStream = eventStreamRepository.findById(id);
+        if(existingStream.isPresent()) {
+            return createEventStream(streamData);
+        } else {
+            EventStreamInfo newStream = new EventStreamInfo(id, streamData);
+            logger.info("Inserting eventstream '{}' with name {}", newStream.getId(), newStream.getName());
+            eventStreamRepository.save(newStream);
+            EventStreamInfo createdStream = eventStreamRepository.findById(id).orElseThrow();
+            _createOrUpdateStream(createdStream);
+            return createdStream;
+        }
+    }
+
+    public List<EventStreamInfo> listEventStreams() {
+        return eventStreamRepository.findAllStream().collect(Collectors.toList());
+    }
+
+    public EventStreamInfo getEventStreamById(String eventStreamId) {
+        Optional<EventStreamInfo> existingStream = eventStreamRepository.findById(eventStreamId);
+        return existingStream.orElseThrow();
+    }
+
+    @Transactional
+    public EventStreamInfo updateEventStream(String eventStreamId, EventStreamData updatedStreamData) {
+        Optional<EventStreamInfo> existingStream = eventStreamRepository.findById(eventStreamId);
+        if(existingStream.isEmpty()) {
+            throw new RuntimeException();
+        } else {
+            EventStreamInfo eventStreamInfo = existingStream.get();
+            if(!updatedStreamData.getName().equals(eventStreamInfo.getName())) {
+                eventStreamInfo.setName(updatedStreamData.getName());
+            }
+            eventStreamInfo.setWebsocketTopic(updatedStreamData.getWebsocket().getTopic());
+            if(updatedStreamData.getBatchSize() != eventStreamInfo.getBatchSize()){
+                eventStreamInfo.setBatchSize(updatedStreamData.getBatchSize());
+            }
+            if(updatedStreamData.getBatchTimeoutMS() != eventStreamInfo.getBatchTimeoutMs()) {
+                eventStreamInfo.setBatchTimeoutMs(updatedStreamData.getBatchTimeoutMS());
+            }
+            if(updatedStreamData.getBlockedRetryDelaySec() != eventStreamInfo.getBatchRetryDelaySec()) {
+                eventStreamInfo.setBatchRetryDelaySec(updatedStreamData.getBlockedRetryDelaySec());
+            }
+            if(updatedStreamData.getErrorHandling() != eventStreamInfo.getErrorHandling()) {
+                eventStreamInfo.setErrorHandling(updatedStreamData.getErrorHandling());
+            }
+            eventStreamRepository.save(eventStreamInfo);
+            EventStreamInfo updatedStream = eventStreamRepository.findById(eventStreamId).orElseThrow();
+            _createOrUpdateStream(updatedStream);
+            return updatedStream;
+        }
+    }
+
+    @Transactional
+    public boolean suspendEventStream(String eventStreamId){
+        Optional<EventStreamInfo> existingStream = eventStreamRepository.findById(eventStreamId);
+        if(existingStream.isEmpty()) {
+            logger.error("Failed to suspend stream {} which doesn't exists.", eventStreamId);
+            throw new NoSuchElementException(String.format("EventStream with id %s not found", eventStreamId));
+        } else {
+            boolean suspendRequired = false;
+            EventStreamInfo eventStreamInfo = existingStream.get();
+            if(!eventStreamInfo.isSuspended()) {
+                logger.info("Persisting stream {} with suspended status {}", eventStreamId, true);
+                eventStreamInfo.setSuspended(true);
+                eventStreamRepository.save(eventStreamInfo);
+                suspendRequired = true;
+            }
+            if(suspendRequired) _suspendStream(eventStreamId);
+            return true;
+        }
+    }
+
+    @Transactional
+    public boolean resumeEventStream(String eventStreamId) {
+        Optional<EventStreamInfo> existingStream = eventStreamRepository.findById(eventStreamId);
+        if(existingStream.isEmpty()) {
+            logger.error("Failed to resume stream {} which doesn't exists.", eventStreamId);
+            throw new NoSuchElementException(String.format("EventStream with id %s not found", eventStreamId));
+        } else {
+            boolean resumeRequired = false;
+            EventStreamInfo eventStreamInfo = existingStream.get();
+            if(eventStreamInfo.isSuspended()) {
+                logger.info("Persisting stream {} with suspended status {}", eventStreamId, false);
+                eventStreamInfo.setSuspended(false);
+                eventStreamRepository.save(eventStreamInfo);
+                resumeRequired = true;
+            }
+            if(resumeRequired) _resumeStream(eventStreamId);
+            return true;
+        }
+    }
+
+    @Transactional
+    public boolean deleteEventStream(String eventStreamId) {
+        Optional<EventStreamInfo> existingStream = eventStreamRepository.findById(eventStreamId);
+        if(existingStream.isEmpty()) {
+            logger.error("Failed to delete stream {} which doesn't exists.", eventStreamId);
+            throw new NoSuchElementException(String.format("EventStream with id %s not found", eventStreamId));
+        } else {
+            Stream<String> subscriptionsToDelete = subscriptionRepository.listSubscriptionIdsByEventStreamId(eventStreamId);
+            // clean subscription runtimes
+            subscriptionsToDelete.forEach(this::deleteSubscription);
+            // clean subscriptions from db
+            subscriptionRepository.deleteInBulkByEventStreamId(eventStreamId);
+            // delete eventstream runtime
+            _deleteStream(eventStreamId);
+            // delete eventstream from db
+            eventStreamRepository.delete(existingStream.get());
+            return true;
+        }
+    }
+
+    private void _createOrResetSubscription(SubscriptionInfo subscriptionInfo) {
+        Subscription subscription = this.subscriptions.get(subscriptionInfo.getId());
+        if(subscription == null) {
+            // create request, create runtime
+            logger.info("Creating subscription runtime for {}", subscriptionInfo.getId());
+            subscription = new Subscription(subscriptionInfo);
+            subscription.setStream(this.streams.get(subscriptionInfo.getStream().getId()));
+            this.subscriptions.put(subscriptionInfo.getId(),subscription);
+        } else {
+            // reset request, reset HWM to get events from the start
+            subscription.setSubscriptionInfo(subscriptionInfo);
+            subscription.setTimeHWM(null);
+        }
+        subscription.initializeOrReset();
+    }
+
+    @Transactional
+    public SubscriptionInfo createSubscription(SubscriptionData subscriptionData) {
+        String id = "sb-"+ UUID.randomUUID().toString();
+        Optional<SubscriptionInfo> existingSub = subscriptionRepository.findById(id);
+        if(existingSub.isPresent()) {
+            return createSubscription(subscriptionData);
+        } else {
+            EventStreamInfo streamInfo = eventStreamRepository.findById(subscriptionData.getStream()).orElseThrow();
+            SubscriptionInfo newSub = new SubscriptionInfo(id, subscriptionData);
+            newSub.setStream(streamInfo);
+            subscriptionRepository.save(newSub);
+            newSub =  subscriptionRepository.findById(id).orElseThrow();
+            _createOrResetSubscription(newSub);
+            return newSub;
+        }
+    }
+
+    public SubscriptionInfo getSubscriptionById(String subscriptionId) {
+        return subscriptionRepository.findById(subscriptionId).orElseThrow();
+    }
+
+    public List<SubscriptionInfo> listSubsciptions(){
+        return subscriptionRepository.findAllSubscriptions().collect(Collectors.toList());
+    }
+
+    @Transactional
+    public boolean deleteSubscription(String subscriptionId) {
+        Optional<SubscriptionInfo> subscriptionInfo = subscriptionRepository.findById(subscriptionId);
+        if(subscriptionInfo.isEmpty()) {
+            logger.error("Failed to delete subscription {} which doesn't exists.", subscriptionId);
+            throw new NoSuchElementException(String.format("Subscription with id %s not found", subscriptionId));
+        } else {
+            // delete subscription runtime
+            _deleteSubscription(subscriptionId);
+            subscriptionRepository.deleteById(subscriptionId);
+            return true;
+        }
+    }
+
+    @Transactional
+    public boolean resetSubscription(String subscriptionId) {
+        Optional<SubscriptionInfo> subscriptionInfo = subscriptionRepository.findById(subscriptionId);
+        if(subscriptionInfo.isEmpty()) {
+            logger.error("Failed to reset subscription {} which doesn't exists.", subscriptionId);
+            throw new NoSuchElementException(String.format("Subscription with id %s not found", subscriptionId));
+        } else {
+            SubscriptionInfo subInfo = subscriptionInfo.get();
+            subInfo.setFromTime(null);
+            subscriptionRepository.save(subInfo);
+            subInfo = subscriptionRepository.findById(subscriptionId).orElseThrow();
+            _createOrResetSubscription(subInfo);
+            return true;
+        }
     }
 }

--- a/connector/src/main/java/io/kaleido/cordaconnector/service/EventStreamService.java
+++ b/connector/src/main/java/io/kaleido/cordaconnector/service/EventStreamService.java
@@ -182,6 +182,7 @@ public class EventStreamService {
                 eventStream = getEventStreamByTopic(topic);
             } catch (Exception e) {
                 logger.error("Received message from client {} on topic {} for which eventstream doesn't exists", connectionId, topic, e);
+                return;
             }
             switch(message.getType()) {
                 case LISTEN:

--- a/connector/src/main/java/io/kaleido/cordaconnector/service/FireFlyService.java
+++ b/connector/src/main/java/io/kaleido/cordaconnector/service/FireFlyService.java
@@ -17,27 +17,54 @@
 package io.kaleido.cordaconnector.service;
 
 import io.kaleido.cordaconnector.exception.CordaConnectionException;
-import io.kaleido.cordaconnector.model.request.BroadcastBatchRequest;
+import io.kaleido.cordaconnector.model.common.BroadcastBatchData;
 import io.kaleido.cordaconnector.rpc.NodeRPCClient;
 import io.kaleido.firefly.cordapp.flows.CreateBroacastBatchFlow;
-import net.corda.core.messaging.FlowHandle;
+import net.corda.core.identity.CordaX500Name;
+import net.corda.core.identity.Party;
 import net.corda.core.transactions.SignedTransaction;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 import java.util.concurrent.ExecutionException;
+import java.util.stream.Collectors;
 
 @Service
 public class FireFlyService {
-
+    private static final Logger logger = LoggerFactory.getLogger(FireFlyService.class);
     @Autowired
     NodeRPCClient rpcClient;
 
     public FireFlyService() {
     }
 
-    public String broadcastBatch(BroadcastBatchRequest request) throws CordaConnectionException, ExecutionException, InterruptedException {
-        SignedTransaction txResult = rpcClient.getRpcProxy().startFlowDynamic(CreateBroacastBatchFlow.class, request.getBatchId(), request.getPayloadRef(), request.getObservers(), request.getGroupId()).getReturnValue().get();
-        return txResult.getId().toString();
+    public Set<Party> validateAndGetParticipants(List<String> participants) throws CordaConnectionException {
+        logger.debug("Validating participant list {}", participants);
+        Set<Party> uniqueParticipants = new HashSet<>();
+        for(String observer: participants) {
+            Party party = rpcClient.getRpcProxy().wellKnownPartyFromX500Name(CordaX500Name.parse(observer));
+            if(party == null) {
+                logger.error("No party with name {} found", observer);
+                throw new RuntimeException("No party with name "+observer+" found.");
+            }
+            uniqueParticipants.add(party);
+        }
+        logger.debug("Valid unique participant set {}", uniqueParticipants);
+        return uniqueParticipants;
+    }
+
+
+    public String broadcastBatch(BroadcastBatchData batchData) throws CordaConnectionException, ExecutionException, InterruptedException {
+        Set<Party> uniqueParticipants = validateAndGetParticipants(batchData.getObservers());
+        Party me = rpcClient.getRpcProxy().nodeInfo().getLegalIdentities().get(0);
+        uniqueParticipants.add(me);
+        List<Party> otherObservers = uniqueParticipants.stream().filter(party -> !party.equals(me)).collect(Collectors.toList());
+        SignedTransaction signedTransaction = rpcClient.getRpcProxy().startTrackedFlowDynamic(CreateBroacastBatchFlow.class, batchData.getBatchId(), batchData.getPayloadRef(), otherObservers, batchData.getGroupId()).getReturnValue().get();
+        return signedTransaction.getId().toString();
     }
 }

--- a/connector/src/main/java/io/kaleido/cordaconnector/service/Subscription.java
+++ b/connector/src/main/java/io/kaleido/cordaconnector/service/Subscription.java
@@ -1,0 +1,292 @@
+// Copyright © 2021 Kaleido, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package io.kaleido.cordaconnector.service;
+
+import io.kaleido.cordaconnector.config.SpringContext;
+import io.kaleido.cordaconnector.db.entity.SubscriptionInfo;
+import io.kaleido.cordaconnector.exception.CordaConnectionException;
+import io.kaleido.cordaconnector.model.common.Event;
+import io.kaleido.cordaconnector.rpc.NodeRPCClient;
+import net.corda.core.contracts.ContractState;
+import net.corda.core.contracts.StateRef;
+import net.corda.core.contracts.TransactionState;
+import net.corda.core.node.services.Vault;
+import net.corda.core.node.services.vault.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import rx.Observable;
+import java.io.IOException;
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static net.corda.core.node.services.vault.QueryCriteriaUtils.DEFAULT_PAGE_NUM;
+
+public class Subscription {
+    public static final Instant BEGINNING = Instant.parse("2009-01-03T10:15:00.00Z");
+    // query page size to be used for pushing past events
+    private static final int PAGE_SIZE=1000;
+    private static final Logger logger = LoggerFactory.getLogger(Subscription.class);
+    // Information about subscription that is persisted
+    private SubscriptionInfo subscriptionInfo;
+    // Stream to which events from this subscription are pushed to
+    private EventStream stream;
+    // timestamp based HWM used for checkpointing
+    private Instant timeHWM;
+    // State class type for this subscription
+    private Class<? extends ContractState> stateTypeClass;
+    // Observable used for listening to future updates on the events the subscription is interested in
+    private Observable<Vault.Update<ContractState>> cordaRx = null;
+
+    private NodeRPCClient rpcClient;
+
+    // Subscription to the observable used fo clean up
+    private rx.Subscription cordaSx = null;
+    private AtomicBoolean isPaused = new AtomicBoolean(false);
+    private static final ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(1);
+
+    public Subscription(SubscriptionInfo subscriptionInfo) {
+        this.subscriptionInfo = subscriptionInfo;
+        this.timeHWM = subscriptionInfo.getFromTime()==null?Instant.now():subscriptionInfo.getFromTime().toInstant();
+        this.rpcClient = SpringContext.getApplicationContext().getBean("nodeRPCClient", NodeRPCClient.class);
+    }
+
+    public boolean isPaused() {
+        return isPaused.get();
+    }
+
+    // pushes all events for the subscription since fromTime by querying the node's vault to eventstream
+    private void pushPastEvents(Instant fromTime) throws ClassNotFoundException {
+        Class<? extends ContractState>  clazz = null;
+        try {
+            clazz = getCordaStateType();
+        } catch (ClassNotFoundException e) {
+            logger.error("{}", subscriptionInfo.getId(),e);
+            throw e;
+        }
+        QueryCriteria.TimeCondition timeCondition = new QueryCriteria.TimeCondition(QueryCriteria.TimeInstantType.RECORDED, new ColumnPredicate.BinaryComparison(BinaryComparisonOperator.GREATER_THAN_OR_EQUAL, fromTime));
+        QueryCriteria criteria = new QueryCriteria.VaultQueryCriteria()
+                .withRelevancyStatus(subscriptionInfo.getRelevancyStatus())
+                .withContractStateTypes(Set.of(clazz))
+                .withStatus(subscriptionInfo.getStateStatus())
+                .withTimeCondition(timeCondition);
+        scheduler.submit(() -> {
+            int currentPage=DEFAULT_PAGE_NUM;
+            while(true) {
+                Vault.Page<ContractState> res  = null;
+                try {
+                    res = rpcClient.getRpcProxy().vaultQueryByWithPagingSpec(
+                            ContractState.class,
+                            criteria,
+                            new PageSpecification(currentPage, PAGE_SIZE)
+                    );
+                } catch (CordaConnectionException e) {
+                    logger.error("{} error while querying vault for past events", subscriptionInfo.getId(), e);
+                    onError();
+                    return;
+                }
+                logger.debug("{} Pushing past events, query to vault finished for page {}", subscriptionInfo.getId(), currentPage);
+                List<Event<TransactionState<ContractState>>> events = new ArrayList<>();
+                for(int i=0; i<res.getStates().size(); i++) {
+                    events.add(new Event<>(res.getStates().get(i).getState(), subscriptionInfo.getId(), res.getStates().get(i).getState().getData().getClass().getCanonicalName(), res.getStates().get(i).getRef(), res.getStatesMetadata().get(i).getRecordedTime(), res.getStatesMetadata().get(i).getConsumedTime()));
+                }
+                events.stream().forEach(event -> {
+                    logger.info("{} pushing new event to stream {}, consumed at {}, recorded at {}", subscriptionInfo.getId(), stream.getEventStreamInfo().getId(), event.getConsumedTime(), event.getRecordedTime());
+                    stream.pushNewEvent(event);
+                });
+                if(res.getStates().size() < PAGE_SIZE) return;
+                currentPage++;
+            }
+        });
+    }
+
+    private Class<? extends ContractState> getCordaStateType() throws ClassNotFoundException {
+        return Class.forName(this.subscriptionInfo.getStateType()).asSubclass(ContractState.class);
+    }
+
+
+    private void processUpdate(Vault.Update<ContractState> update) throws ClassNotFoundException {
+        logger.debug("{} processing vault update, consumed:{}, produced:{}", subscriptionInfo.getId(), update.getConsumed().size(), update.getProduced().size());
+        if(stateTypeClass == null) {
+            try {
+                stateTypeClass = getCordaStateType();
+            } catch (ClassNotFoundException e) {
+                logger.error("{} class for type is not in classpath {}", subscriptionInfo.getId(), subscriptionInfo.getStateType(), e);
+                throw e;
+            }
+        }
+        List<StateRef> stateRefs = new ArrayList<>();
+        update.getConsumed().stream().forEach(state -> stateRefs.add(state.getRef()));
+        update.getProduced().stream().forEach(state -> stateRefs.add(state.getRef()));
+        logger.debug("{} querying vault to post process update, stateType {}, stateRefs {}, state status {}, state relevancy status {}", subscriptionInfo.getId(), stateTypeClass, stateRefs, subscriptionInfo.getStateStatus(), subscriptionInfo.getRelevancyStatus());
+        QueryCriteria criteria = new QueryCriteria.VaultQueryCriteria()
+                .withRelevancyStatus(subscriptionInfo.getRelevancyStatus())
+                .withContractStateTypes(Set.of(stateTypeClass))
+                .withStateRefs(stateRefs)
+                .withStatus(subscriptionInfo.getStateStatus());
+
+        scheduler.submit(() -> {
+            int currentPage = DEFAULT_PAGE_NUM;
+            while (true) {
+                Vault.Page<ContractState> res;
+                try {
+                    res = rpcClient.getRpcProxy().vaultQueryByWithPagingSpec(
+                            ContractState.class,
+                            criteria,
+                            new PageSpecification(currentPage, PAGE_SIZE)
+                    );
+                } catch (CordaConnectionException e) {
+                    logger.error("{} error in processing update, failed to fetch states from vault",subscriptionInfo.getId(), e);
+                    onError();
+                    return;
+                }
+                logger.debug("{} Post process of update event,  query to vault finished for page {}, size {}", subscriptionInfo.getId(), currentPage, res.getStates().size());
+                List<Event<TransactionState<ContractState>>> events = new ArrayList<>();
+                for (int i = 0; i < res.getStates().size(); i++) {
+                    events.add(new Event<>(res.getStates().get(i).getState(), subscriptionInfo.getId(), res.getStates().get(i).getState().getData().getClass().getCanonicalName(), res.getStates().get(i).getRef(), res.getStatesMetadata().get(i).getRecordedTime(), res.getStatesMetadata().get(i).getConsumedTime()));
+                }
+                events.stream().forEach(event -> {
+                    // Discard past events if any
+                    // stale consumed update
+                    if(event.getConsumedTime() != null && (this.timeHWM.isAfter(event.getConsumedTime()) || this.timeHWM.equals(event.getConsumedTime()))) return;
+                    // stale produced update
+                    if(event.getConsumedTime() == null && (this.timeHWM.isAfter(event.getRecordedTime()) || this.timeHWM.equals(event.getRecordedTime()))) return;
+
+                    logger.info("{} pushing new event to stream {}, consumed at {}, recorded at {}", subscriptionInfo.getId(), stream.getEventStreamInfo().getId(), event.getConsumedTime(), event.getRecordedTime());
+                    stream.pushNewEvent(event);
+                });
+                if(res.getStates().size() < PAGE_SIZE) return;
+                currentPage++;
+            }
+        });
+    }
+
+    private void _setupCordaObservable() throws IOException, CordaConnectionException {
+        // Subscribe to future updates
+        logger.info("{} creating future observables", subscriptionInfo.getId());
+        QueryCriteria criteria = new QueryCriteria.VaultQueryCriteria()
+                .withRelevancyStatus(subscriptionInfo.getRelevancyStatus())
+                .withStatus(subscriptionInfo.getStateStatus());
+        // we are interested only in updates, but need to specify pagination to avoid pagination exceptions when vault has more results than default page size (200)
+        cordaRx = rpcClient.getRpcProxy().vaultTrackByWithPagingSpec(ContractState.class, criteria, new PageSpecification(1, 1)).getUpdates();
+        cordaSx = cordaRx.subscribe(update -> {
+            try {
+                processUpdate(update);
+            } catch (ClassNotFoundException e) {
+                logger.error("{} failed to process update received from corda, pausing subscription", subscriptionInfo.getId(), e);
+                onError();
+            }
+        });
+    }
+
+    private void _cleanupObservable() {
+        if(this.cordaSx != null && !this.cordaSx.isUnsubscribed()) {
+            logger.info("{} Unsubscribed from future updates", subscriptionInfo.getId());
+            this.cordaSx.unsubscribe();
+        }
+    }
+
+    public void initializeOrReset() {
+        logger.info("{} initializing subscription...", subscriptionInfo.getId());
+        // clear stream checkpoints if any
+        stream.clearCheckpoints();
+        Timestamp startTime = subscriptionInfo.getFromTime();
+        Timestamp lastCheckPoint = subscriptionInfo.getLastCheckpoint();
+        if(lastCheckPoint != null) startTime = lastCheckPoint;
+        if (Instant.now().isAfter(startTime.toInstant())) {
+            // Push past events;
+            this.timeHWM = startTime.toInstant();
+            try {
+                pushPastEvents(startTime.toInstant());
+            } catch (ClassNotFoundException e) {
+                logger.error("{} Failed to initialize subscription", subscriptionInfo.getId(),e);
+                onError();
+                return;
+            }
+        }
+        // cleanup existing observable
+        _cleanupObservable();
+        try {
+            _setupCordaObservable();
+        } catch (IOException | CordaConnectionException e) {
+            logger.error("{} Failed to initialize subscription", subscriptionInfo.getId(),e);
+            onError();
+            return;
+        }
+        isPaused.set(false);
+    }
+
+    public void pauseSubscription(){
+        logger.info("{} Pausing subscription", subscriptionInfo.getId());
+        isPaused.set(true);
+        _cleanupObservable();
+    }
+
+    public void resumeSubscription(){
+        //push past events
+        logger.info("{} Resuming subscription", subscriptionInfo.getId());
+        try {
+            pushPastEvents(this.timeHWM);
+        } catch (ClassNotFoundException e) {
+            logger.error("{} Failed to resume subscription", subscriptionInfo.getId(),e);
+            onError();
+            return;
+        }
+        try {
+            _setupCordaObservable();
+        } catch (IOException | CordaConnectionException e) {
+            logger.error("{} Failed to resume subscription", subscriptionInfo.getId(),e);
+            onError();
+            return;
+        }
+        isPaused.set(false);
+    }
+
+    public SubscriptionInfo getSubscriptionInfo() {
+        return subscriptionInfo;
+    }
+
+    public void setSubscriptionInfo(SubscriptionInfo subscriptionInfo) {
+        this.subscriptionInfo = subscriptionInfo;
+    }
+
+    public void onError() {
+        pauseSubscription();
+    }
+
+    public EventStream getStream() {
+        return stream;
+    }
+
+    public void setStream(EventStream stream) {
+        this.stream = stream;
+    }
+
+    public Instant getTimeHWM() {
+        return timeHWM;
+    }
+
+    public void setTimeHWM(Instant timeHWM) {
+        this.timeHWM = timeHWM;
+    }
+}
+

--- a/connector/src/main/java/io/kaleido/cordaconnector/service/data/BroadcastBatchResponse.java
+++ b/connector/src/main/java/io/kaleido/cordaconnector/service/data/BroadcastBatchResponse.java
@@ -18,6 +18,5 @@ package io.kaleido.cordaconnector.service.data;
 
 public class BroadcastBatchResponse {
     public BroadcastBatchResponse() {
-
     }
 }

--- a/connector/src/main/java/io/kaleido/cordaconnector/ws/ClientMessage.java
+++ b/connector/src/main/java/io/kaleido/cordaconnector/ws/ClientMessage.java
@@ -14,12 +14,38 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package io.kaleido.cordaconnector.config;
+package io.kaleido.cordaconnector.ws;
 
-import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.context.annotation.Configuration;
+public class ClientMessage {
+    private ClientMessageType type;
+    private String topic;
+    private String message;
 
-@Configuration
-@ConfigurationProperties("db")
-public class EventStreamConfig {
+    public ClientMessage() {
+
+    }
+
+    public ClientMessageType getType() {
+        return type;
+    }
+
+    public void setType(ClientMessageType type) {
+        this.type = type;
+    }
+
+    public String getTopic() {
+        return topic;
+    }
+
+    public void setTopic(String topic) {
+        this.topic = topic;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public void setMessage(String message) {
+        this.message = message;
+    }
 }

--- a/connector/src/main/java/io/kaleido/cordaconnector/ws/ClientMessageDecoder.java
+++ b/connector/src/main/java/io/kaleido/cordaconnector/ws/ClientMessageDecoder.java
@@ -1,0 +1,62 @@
+// Copyright © 2021 Kaleido, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package io.kaleido.cordaconnector.ws;
+
+import com.fasterxml.jackson.databind.MapperFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import javax.websocket.DecodeException;
+import javax.websocket.Decoder;
+import javax.websocket.EndpointConfig;
+import java.io.IOException;
+
+public class ClientMessageDecoder implements Decoder.Text<ClientMessage>{
+    final ObjectMapper objectMapper;
+
+    public ClientMessageDecoder() {
+        objectMapper = CustomMapper();
+    }
+
+    private ObjectMapper CustomMapper() {
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.enable(MapperFeature.ACCEPT_CASE_INSENSITIVE_ENUMS);
+        return mapper;
+    }
+    @Override
+    public ClientMessage decode(String s) throws DecodeException {
+        try {
+            return objectMapper.readValue(s, ClientMessage.class);
+        } catch (IOException e) {
+            throw new DecodeException(s, e.getMessage(), e);
+        }
+    }
+
+    @Override
+    public boolean willDecode(String s) {
+        return s != null;
+    }
+
+    @Override
+    public void init(EndpointConfig config) {
+
+    }
+
+    @Override
+    public void destroy() {
+
+    }
+}

--- a/connector/src/main/java/io/kaleido/cordaconnector/ws/ClientMessageType.java
+++ b/connector/src/main/java/io/kaleido/cordaconnector/ws/ClientMessageType.java
@@ -14,8 +14,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package io.kaleido.cordaconnector.model.response.data;
+package io.kaleido.cordaconnector.ws;
 
-public enum ErrorHandling {
-    BLOCK, SKIP;
+public enum ClientMessageType {
+    LISTEN, ACK, ERROR
 }

--- a/connector/src/main/java/io/kaleido/cordaconnector/ws/EventServerSocket.java
+++ b/connector/src/main/java/io/kaleido/cordaconnector/ws/EventServerSocket.java
@@ -1,0 +1,63 @@
+// Copyright © 2021 Kaleido, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package io.kaleido.cordaconnector.ws;
+
+import io.kaleido.cordaconnector.config.SpringContext;
+import io.kaleido.cordaconnector.service.EventStreamService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import javax.websocket.*;
+import javax.websocket.server.ServerEndpoint;
+
+@Component
+@ServerEndpoint(value = "/ws", decoders = {ClientMessageDecoder.class}, encoders = {GenericEncoder.class})
+public class EventServerSocket {
+    private static final Logger logger = LoggerFactory.getLogger(EventServerSocket.class);
+    private final EventStreamService eventStreamService;
+    public EventServerSocket() {
+        this.eventStreamService = SpringContext.getApplicationContext().getBean("eventStreamService", EventStreamService.class);
+    }
+    @OnOpen
+    public void onWebSocketConnect(Session sess)
+    {
+        logger.info("WS: Client Connected, id:{}", sess.getId());
+        eventStreamService.addWebSocketConnection(new WebSocketConnection(sess.getId(), sess));
+    }
+
+    @OnMessage
+    public void onWebSocketText(Session sess, ClientMessage message)
+    {
+        logger.info("WS: -> received message, client id: {}", sess.getId());
+        eventStreamService.onWebSocketMessage(sess.getId(), message);
+    }
+
+    @OnClose
+    public void onWebSocketClose(Session session, CloseReason reason)
+    {
+        logger.info("WS: Client connection with id {} closed, code {}, reason {}", session.getId(), reason.getCloseCode(), reason.getReasonPhrase());
+        eventStreamService.removeWebSocketConnection(session.getId());
+    }
+
+    @OnError
+    public void onWebSocketError(Session session, Throwable cause)
+    {
+        logger.error("WS: Client with id {} returned a error", session.getId(), cause);
+    }
+
+}

--- a/connector/src/main/java/io/kaleido/cordaconnector/ws/GenericEncoder.java
+++ b/connector/src/main/java/io/kaleido/cordaconnector/ws/GenericEncoder.java
@@ -1,0 +1,57 @@
+// Copyright © 2021 Kaleido, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package io.kaleido.cordaconnector.ws;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.MapperFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import net.corda.client.jackson.JacksonSupport;
+
+import javax.websocket.EncodeException;
+import javax.websocket.Encoder;
+import javax.websocket.EndpointConfig;
+
+public class GenericEncoder implements Encoder.Text<Object> {
+    final ObjectMapper cordaObjectMapper = CordaObjectMapper();
+    private final ObjectMapper CordaObjectMapper() {
+        ObjectMapper mapper = JacksonSupport.createNonRpcMapper();
+        mapper.enable(MapperFeature.ACCEPT_CASE_INSENSITIVE_ENUMS);
+        mapper.registerModule(new JavaTimeModule());
+        mapper.registerModule(new Jdk8Module());
+        return mapper;
+    }
+    @Override
+    public String encode(Object object) throws EncodeException {
+        try {
+            return cordaObjectMapper.writeValueAsString(object);
+        } catch (JsonProcessingException e) {
+            throw new EncodeException(object, e.getMessage(), e);
+        }
+    }
+
+    @Override
+    public void init(EndpointConfig config) {
+
+    }
+
+    @Override
+    public void destroy() {
+
+    }
+}

--- a/connector/src/main/java/io/kaleido/cordaconnector/ws/WebSocketConnection.java
+++ b/connector/src/main/java/io/kaleido/cordaconnector/ws/WebSocketConnection.java
@@ -1,0 +1,52 @@
+// Copyright © 2021 Kaleido, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package io.kaleido.cordaconnector.ws;
+
+import javax.websocket.CloseReason;
+import javax.websocket.EncodeException;
+import javax.websocket.Session;
+import java.io.IOException;
+
+public class WebSocketConnection {
+    private String id;
+    private Session session;
+
+    public WebSocketConnection(String id, Session session) {
+        this.id = id;
+        this.session = session;
+    }
+
+    public boolean isOpen() {
+        return this.session.isOpen();
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public Session getSession() {
+        return session;
+    }
+
+    public void close() throws IOException {
+        session.close(new CloseReason(CloseReason.CloseCodes.GOING_AWAY, "Going away."));
+    }
+
+    public void sendData(Object data) throws IOException, EncodeException {
+        session.getBasicRemote().sendObject(data);
+    }
+}

--- a/connector/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/connector/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -1,0 +1,6 @@
+databaseChangeLog:
+- changeSet:
+    id:  0.1
+    author:  Kaleido Inc
+    changes:
+      -  empty:  {}

--- a/connector/src/test/resources/application.yml
+++ b/connector/src/test/resources/application.yml
@@ -1,12 +1,9 @@
 rpc:
   host: "localhost:10001"
-  username: "test"
+  username: "user"
   password: "test"
 db:
   driverClassName: "org.h2.Driver"
   url: "jdbc:h2:mem:test;TRACE_LEVEL_SYSTEM_OUT=2"
   username: "test"
   password: "test"
-spring:
-    jpa.generate-ddl: true
-

--- a/cordapp/firefly-contracts/build.gradle
+++ b/cordapp/firefly-contracts/build.gradle
@@ -17,6 +17,11 @@ repositories {
     maven { url 'https://repo.gradle.org/gradle/libs-releases' }
 }
 
+// Corda serialization requires function parameter names to be included in the class file
+compileJava {
+    options.compilerArgs << '-parameters'
+}
+
 dependencies {
     // these dependencies will NOT be included in the contract jar
     cordaCompile 'net.corda:corda-core:4.4'

--- a/cordapp/firefly-contracts/src/main/java/io/kaleido/firefly/cordapp/contracts/FireflyContract.java
+++ b/cordapp/firefly-contracts/src/main/java/io/kaleido/firefly/cordapp/contracts/FireflyContract.java
@@ -87,7 +87,7 @@ public class FireflyContract implements Contract {
                     signers.containsAll(keys));
             require.using("author should be one of the participants", keys.contains(out.getAuthor().getOwningKey()));
             require.using("The nonce value must be 0.",
-                    out.getNonce() == 0);
+                    out.getNonce() == 0L);
             return null;
         });
     }

--- a/cordapp/firefly-contracts/src/main/java/io/kaleido/firefly/cordapp/states/BroadcastBatch.java
+++ b/cordapp/firefly-contracts/src/main/java/io/kaleido/firefly/cordapp/states/BroadcastBatch.java
@@ -1,8 +1,3 @@
-package io.kaleido.firefly.cordapp.states;
-
-import net.corda.core.identity.AbstractParty;
-import net.corda.core.identity.Party;
-import org.jetbrains.annotations.NotNull;
 // Copyright © 2021 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
@@ -19,9 +14,18 @@ import org.jetbrains.annotations.NotNull;
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+package io.kaleido.firefly.cordapp.states;
+
+import io.kaleido.firefly.cordapp.contracts.FireflyContract;
+import net.corda.core.contracts.BelongsToContract;
+import net.corda.core.identity.AbstractParty;
+import net.corda.core.identity.Party;
+import org.jetbrains.annotations.NotNull;
+
 import java.util.ArrayList;
 import java.util.List;
 
+@BelongsToContract(FireflyContract.class)
 public class BroadcastBatch implements FireflyEvent {
     private final Party author;
     private final String batchId;

--- a/cordapp/firefly-flows/build.gradle
+++ b/cordapp/firefly-flows/build.gradle
@@ -17,6 +17,11 @@ repositories {
     maven { url 'https://repo.gradle.org/gradle/libs-releases' }
 }
 
+// Corda serialization requires function parameter names to be included in the class file
+compileJava {
+    options.compilerArgs << '-parameters'
+}
+
 cordapp {
     targetPlatformVersion 4
     minimumPlatformVersion 4

--- a/cordapp/firefly-flows/src/main/java/io/kaleido/firefly/cordapp/flows/CreateGroupNonceFlow.java
+++ b/cordapp/firefly-flows/src/main/java/io/kaleido/firefly/cordapp/flows/CreateGroupNonceFlow.java
@@ -34,6 +34,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+@StartableByRPC
 @InitiatingFlow
 public class CreateGroupNonceFlow extends FlowLogic<StateAndRef<FireflyGroupNonce>> {
     private final UniqueIdentifier groupId;
@@ -81,7 +82,7 @@ public class CreateGroupNonceFlow extends FlowLogic<StateAndRef<FireflyGroupNonc
         final Command<FireflyContract.Commands.OrderingGroupCreate> txCommand = new Command<>(
                 new FireflyContract.Commands.OrderingGroupCreate(),
                 signers);
-        final FireflyGroupNonce groupNonce = new FireflyGroupNonce(groupId, getOurIdentity(), partiesForContext, 0);
+        final FireflyGroupNonce groupNonce = new FireflyGroupNonce(groupId, getOurIdentity(), partiesForContext, 0L);
 
         final TransactionBuilder txBuilder = new TransactionBuilder(notary)
                 .addOutputState(groupNonce, FireflyContract.ID)


### PR DESCRIPTION
This PR includes
- [x] spring boot application `connector`
   - [x] eventstream management REST APIS for corda, similar to ethconnect
   - [x] WebSockets support to listen on corda events
   - [x] REST API to interact with firefly cordapp (`/broadcastBatch`) 
   - [x] Swagger support for REST endpoints 
- [x] Fixes to firefly cordapp (adds missing logic inside firefly-flows cordapp)
- [x] Updates to readme

Signed-off-by: amit panghal <amit.panghal@kaleido.io>